### PR TITLE
fix: develop 배포 워크플로우에서 build 시 스프링부트 서버 환경변수 로드 에러 해결

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # ENV 로드, Github ENV 등록
+      - name: Load ENV into Environment Variable
+        run: echo "${{ secrets.ENV }}" >> $GITHUB_ENV
+
       # JDK 17 세팅
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #5 

## 📌 작업 내용 및 특이사항

- develop 브랜치로 push 이벤트가 발생할 때 실행되는 develop_build_deploy 워크플로우에서 ./gradlew build 시 스프링부트 서버에서 환경변수를 읽어오지 못하는 에러가 발생했습니다
- develop_build_deploy 워크플로우에 Github Environment DEV.ENV 값을 로드하고 $GITHUB_ENV 로 등록해주는 작업을 추가해 build 시 스프링부트 서버에서 환경변수를 읽을 수 있도록 설정

## 🔍 참고사항

-