### PR TITLE
refactor: 테스트 환경 db 변경과 설정 및 세팅 수정

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -25,6 +25,16 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      # 테스트 환경에서 필요한 컨테이너 실행 (redis, postgres)
+      - name: Run Containers
+        run: docker compose -f ./docker-compose-test.yml up -d
+
+      # 테스트 환경에서 필요한 스키마, 데이터 등록
+      - name: Apply Schema and Data
+        run: |
+          echo "${{ secrets.SCHEMA_SQL }}" > src/test/resources/test-schema.sql
+          echo "${{ secrets.DATA_SQL }}" > src/test/resources/test-data.sql
+
       # Gradlew 실행 권한 허용
       - name: Grant Execute Permission for Gradlew
         run: chmod +x ./gradlew

--- a/.github/workflows/develop_pull_request.yml
+++ b/.github/workflows/develop_pull_request.yml
@@ -20,6 +20,16 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      # 테스트 환경에서 필요한 컨테이너 실행 (redis, postgres)
+      - name: Run Containers
+        run: docker compose -f ./docker-compose-test.yml up -d
+
+      # 테스트 환경에서 필요한 스키마, 데이터 등록
+      - name: Apply Schema and Data
+        run: |
+          echo "${{ secrets.SCHEMA_SQL }}" > src/test/resources/test-schema.sql
+          echo "${{ secrets.DATA_SQL }}" > src/test/resources/test-data.sql
+
       # Gradlew 실행 권한 허용
       - name: Grant Execute Permission for Gradlew
         run: chmod +x ./gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### env ###
 .env
+
+### sql ###
+*.sql

--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
-    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.9.3'
-
 
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,14 @@
+services:
+  redis:
+    image: "redis:alpine"
+    ports:
+      - "6379:6379"
+
+  postgres:
+    image: "postgres:alpine"
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: "ftm_test_db"  # DB 자동 생성

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -37,7 +37,7 @@
     </appender>
 
     <!-- 테스트 환경 -->
-    <springProfile name="local">
+    <springProfile name="test">
         <root level="INFO">
             <appender-ref ref="CONSOLE" />
         </root>

--- a/src/test/java/com/ftm/server/ServerApplicationTests.java
+++ b/src/test/java/com/ftm/server/ServerApplicationTests.java
@@ -1,11 +1,16 @@
 package com.ftm.server;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @TestPropertySource(locations = "file:.env")
+@AutoConfigureTestDatabase(
+        replace = AutoConfigureTestDatabase.Replace.NONE) // 테스트 시 내장된 인메모리 DB를 사용하지 않는다는 설정
 class ServerApplicationTests {
 
     @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,10 +4,13 @@ spring:
       on-profile: "test"
 
   datasource:
-    url: jdbc:h2:mem:testDb;MODE=POSTGRESQL
+    url: jdbc:postgresql://localhost:5432/ftm_test_db
+    username: test
+    password: test
+    driver-class-name: org.postgresql.Driver
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: none
     show-sql: true
@@ -15,3 +18,10 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 1000
+
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:test-schema.sql
+      data-locations: classpath:test-data.sql
+


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #19 

## 📌 작업 내용 및 특이사항

- 기존 테스트 환경의 H2 인메모리 DB 에서 개발환경과 동일한 postgresql 로 변경했습니다. H2 DB mode를 postgresql 로 설정해도 지원되지 않는 부분(ARRAY[] 타입 지원 등)이 존재하고 테스트도 개발환경과 일관된 환경에서 수행하기 위해 변경했습니다
- CICD 환경에서 테스트 실행 시 redis, postgres 를 실행하기 위해 docker-compose-test.yml 도커 컴포즈 파일을 작성하고 워크플로에서 실행하도록 작업 구성했습니다 (774eed6c306d499a10407b7d07a71efa71fce131, 1ec6df781a65229ceca5a2bba94090f689ce0666)
- CICD 환경에서 스키마, 데이터 sql 파일을 생성해 등록되도록 구성했습니다


## 🔍 참고사항

- 테스트 클래스에 `@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)` 어노테이션을 추가했습니다. 이 어노테이션이 없으면, 스프링 부트는 테스트 실행 시 자동으로 내장된 인메모리 DB(H2)를 사용하려고 하기 때문에 application.yml 파일의 spring.datasource.url 및 driver-class-name 을 다른 DB 정보를 설정해도 해당 DB와 연결할 수 없다는 에러가 발생합니다 (H2 등의 인메모리 DB가 아닌 다른 DB 정보를 설정했기 때문에)
이 어노테이션을 추가해서 테스트 환경에서도 애플리케이션이 실제 사용하는 DB와 연결되도록 설정했습니다.

## 📚 기타

- *.sql 파일 .gitignore 적용
- logback-spring.xml 파일에서 test 환경의 로그 설정에 profile 정보 ocal -> test 로 수정