### PR TITLE
feat: 시큐리티 기본 설정 및 핸들러 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // Security
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.session:spring-session-data-redis'
 

--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,109 @@
+package com.ftm.server.infrastructure.security;
+
+import com.ftm.server.infrastructure.security.handler.PermissionDeniedHandler;
+import com.ftm.server.infrastructure.security.handler.UnauthenticatedAccessHandler;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity(debug = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final UnauthenticatedAccessHandler unauthenticatedAccessHandler;
+    private final PermissionDeniedHandler permissionDeniedHandler;
+
+    // CORS 에서 허용할 HTTP 메서드 목록
+    public static final List<HttpMethod> CORS_ALLOWED_METHODS =
+            List.of(
+                    HttpMethod.GET,
+                    HttpMethod.POST,
+                    HttpMethod.PUT,
+                    HttpMethod.PATCH,
+                    HttpMethod.DELETE,
+                    HttpMethod.HEAD);
+
+    // CORS 에서 허용할 도메인 목록
+    public static final List<String> CORS_ALLOWED_ORIGINS =
+            List.of(
+                    "http://localhost:8080", // 로컬 환경 서버 도메인
+                    "https://dev-api.fittheman.site", // 개발 환경 서버 도메인
+                    "https://fittheman.site"); // 개발 환경 클라이언트 도메인
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // csrf 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                // http basic 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // 폼로그인 비활성화
+                .formLogin(AbstractHttpConfigurer::disable)
+                // 로그아웃 비활성화
+                .logout(AbstractHttpConfigurer::disable)
+                // 세션 관리
+                .sessionManagement(
+                        session ->
+                                session.sessionFixation()
+                                        .migrateSession() // 세션 고정 보호
+                                        .maximumSessions(1) // 동시 로그인 1개 제한
+                                        .maxSessionsPreventsLogin(false)) // 기존 세션 만료 후 새 로그인 허용
+                // 예외 핸들링
+                .exceptionHandling(
+                        exception ->
+                                exception
+                                        // 인증되지 않은 요청 예외 처리
+                                        .authenticationEntryPoint(unauthenticatedAccessHandler)
+                                        // 접근 권한 부족 예외 처리
+                                        .accessDeniedHandler(permissionDeniedHandler))
+                // cors 설정
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // 경로 인가 설정
+                .authorizeHttpRequests(
+                        authorize -> {
+                            authorize
+                                    // 정적 리소스 경로 허용
+                                    .requestMatchers("/docs/**")
+                                    .permitAll();
+
+                            // TODO: 요청 허용 특정 API 추가 (회원가입, 로그인 등)
+
+                            // 그 외 모든 요청은 인증 필요
+                            authorize.anyRequest().authenticated();
+                        });
+
+        return http.build();
+    }
+
+    // Password 암호화 설정
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // CORS 설정
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedHeader("*");
+        CORS_ALLOWED_ORIGINS.forEach(config::addAllowedOriginPattern);
+        CORS_ALLOWED_METHODS.forEach(config::addAllowedMethod);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/security/handler/PermissionDeniedHandler.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/handler/PermissionDeniedHandler.java
@@ -1,0 +1,33 @@
+package com.ftm.server.infrastructure.security.handler;
+
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.context.SecurityContextPersistenceFilter;
+import org.springframework.stereotype.Component;
+
+/** 인증은 되었지만 접근 권한이 없는 경우 예외처리하는 핸들러 */
+@Component
+@RequiredArgsConstructor
+public class PermissionDeniedHandler implements AccessDeniedHandler {
+
+    private final SecurityResponseHandler securityResponseHandler;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+        securityResponseHandler.sendResponse(
+                response, ApiResponse.fail(ErrorResponseCode.NOT_AUTHORIZATION));
+
+        SecurityContextPersistenceFilter filter = new SecurityContextPersistenceFilter();
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/security/handler/SecurityResponseHandler.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/handler/SecurityResponseHandler.java
@@ -1,0 +1,28 @@
+package com.ftm.server.infrastructure.security.handler;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ftm.server.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** 시큐리티 필터단에서 응답을 처리하는 핸들러 */
+@Component
+@RequiredArgsConstructor
+public class SecurityResponseHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public <T> void sendResponse(HttpServletResponse response, ApiResponse<T> apiResponse)
+            throws IOException {
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+
+        response.setStatus(apiResponse.getStatus());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/security/handler/UnauthenticatedAccessHandler.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/handler/UnauthenticatedAccessHandler.java
@@ -1,0 +1,30 @@
+package com.ftm.server.infrastructure.security.handler;
+
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+/** 인증이 필요한 요청에서 인증되지 않은 유저가 요청할 경우 예외처리하는 핸들러 */
+@Component
+@RequiredArgsConstructor
+public class UnauthenticatedAccessHandler implements AuthenticationEntryPoint {
+
+    private final SecurityResponseHandler securityResponseHandler;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException)
+            throws IOException, ServletException {
+        securityResponseHandler.sendResponse(
+                response, ApiResponse.fail(ErrorResponseCode.NOT_AUTHENTICATED));
+    }
+}

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -3,22 +3,9 @@ spring:
     activate:
       on-profile: "security"
 
-  security:
-    oauth2:
-      client:
-        registration:
-          kakao:
-            client-id: ${KAKAO_CLIENT_ID}
-            client-secret: ${KAKAO_CLIENT_SECRET}
-            client-authentication-method: client_secret_post
-            authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
-            client-name: Kakao
-            provider: kakao
-        provider:
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-info-authentication-method: header
-            user-name-attribute: id
+  kakao:
+    clinet-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: "${BASE_URL}/api/auth/kakao/callback"
+    token-uri: "https://kauth.kakao.com/oauth/token"
+    user-info-uri: "https://kapi.kakao.com/v2/user/me"


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #23 

## 📌 작업 내용 및 특이사항

- 스프링 시큐리티 관련 기본 설정 추가 작업했습니다.
- 카카오 로그인 시 클라이언트에서 인증 로직을 수행한 후 서버로 요청하는 방식을 채택하면서 Security OAuth2 를 사용하지 않기로 결정해 OAuth2 의존성 및 application 설정 내용 변경했습니다.
- 기본 시큐리티 config 설정 파일을 추가했습니다. (csrf, cors, exception handle 등)
- 시큐리티 필터단에서 인증, 인가(권한)에 대한 예외를 핸들링하는 UnauthenticatedAccessHandler, PermissionDeniedHandler 와 시큐리티 필터단에서 응답 로직을 담당하는 SecurityResponseHandler 구현했습니다.

## 🔍 참고사항

- 시큐리티에서 사용하는 인증 객체 UserDetails 와 인증 서비스 객체 UserDetailsService 는 추후 인증 로직을 구현하면서 판단 후에 함께 구현하면 될 것 같습니다
- 로그인 시 세션 인증과 관리 방식에 대해서도 인증 로직을 구현하면서 테스트를 통해 설정을 추가하거나 변경해야할 것 같습니다

## 📚 기타

-