### PR TITLE
chore: cicd 환경 스키마, 데이터 init 및 문서화 작업 step 추가

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -55,13 +55,21 @@ jobs:
         run: |
           echo "${{ secrets.ENV }}" >> .env
 
+      # Swagger API 문서화 task 실행
+      - name: Apply Swagger API Document Task
+        run: ./gradlew copyOasToSwagger
+
+      # Rest Docs API 문서화 task 실행
+      - name: Apply Rest Docs API Document Task
+        run: ./gradlew copyDocument
+
       # Gradle 빌드
       - name: Build with Gradle
         id: gradle
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
-            build
+            bootJar
             --scan
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
 

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -31,9 +31,20 @@ jobs:
 
       # 테스트 환경에서 필요한 스키마, 데이터 등록
       - name: Apply Schema and Data
+        env:
+          TEST_POSTGRES_CONTAINER_NAME: "${{ github.event.repository.name }}-postgres-1"
+          TEST_POSTGRES_USER: test
+          TEST_POSTGRES_DB: ftm_test_db
         run: |
-          echo "${{ secrets.SCHEMA_SQL }}" > src/test/resources/test-schema.sql
-          echo "${{ secrets.DATA_SQL }}" > src/test/resources/test-data.sql
+          echo "⏳ Waiting for postgres to be ready..."
+          until docker exec -i $TEST_POSTGRES_CONTAINER_NAME pg_isready -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB; do
+            echo "postgres is not ready yet. Retrying in 3 seconds..."
+            sleep 3
+          done
+          echo "✅ postgres is ready!"
+
+          echo "${{ secrets.SCHEMA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+          echo "${{ secrets.DATA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
 
       # Gradlew 실행 권한 허용
       - name: Grant Execute Permission for Gradlew

--- a/.github/workflows/develop_pull_request.yml
+++ b/.github/workflows/develop_pull_request.yml
@@ -26,9 +26,20 @@ jobs:
 
       # 테스트 환경에서 필요한 스키마, 데이터 등록
       - name: Apply Schema and Data
+        env:
+          TEST_POSTGRES_CONTAINER_NAME: "${{ github.event.repository.name }}-postgres-1"
+          TEST_POSTGRES_USER: test
+          TEST_POSTGRES_DB: ftm_test_db
         run: |
-          echo "${{ secrets.SCHEMA_SQL }}" > src/test/resources/test-schema.sql
-          echo "${{ secrets.DATA_SQL }}" > src/test/resources/test-data.sql
+          echo "⏳ Waiting for postgres to be ready..."
+          until docker exec -i $TEST_POSTGRES_CONTAINER_NAME pg_isready -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB; do
+            echo "postgres is not ready yet. Retrying in 3 seconds..."
+            sleep 3
+          done
+          echo "✅ postgres is ready!"
+          
+          echo "${{ secrets.SCHEMA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+          echo "${{ secrets.DATA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
 
       # Gradlew 실행 권한 허용
       - name: Grant Execute Permission for Gradlew


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #24

## 📌 작업 내용 및 특이사항

- spring boot 설정에서 sql > init > mode: always 로 설정하면 추후 @SpringBootTest 클래스가 늘어나면 그 수만큼 실행되면서 에러가 발생할 가능성이 있음. 그래서 cicd 환경에서 test postgres 컨테이너를 실행시키고 직접 컨테이너에 접속해 스키마, 데이터 init 작업을 한번만 수행하도록 작업을 변경했습니다
- deploy 워크플로에서 swagger api 문서화, rest docs api 문서화 task 를 실행해 배포 환경에서 api 문서화 파일에 접근 할 수 있도록 구성했습니다
- `build` 대신 `bootJar` 로 바꿔 실행 가능한 Spring Boot JAR 파일만 만들어 배포할 수 있도록 수정했습니다. `develop` 브랜치의 `Pull Request` 워크플로에서 `check` 테스크 를 수행해 검증된 후에 `build deploy` 워크플로 실행이 가능하고 Swagger API 문서화 테스크에서도 `test` 를 수행해 검증이 이루어지기 때문에 `build` 대신 `bootJar` 테스크만 실행해 중복 작업을 줄이고 빌드 속도를 최적화했습니다 

## 🔍 참고사항

- ~~테스트용 PR -> 실제 스키마, 데이터가 잘 init 되는지 확인 후 build_develop 워크플로에도 적용하고 문서화 작업 실행 step 도 추가할 예정~~

## 📚 기타

-