### PR TITLE
fix: 베포 워크플로에서 asciidoctor snippet 경로를 인식하지 못하는 에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -74,8 +78,11 @@ dependencies {
 
 }
 
+jar.enabled = false
+
 tasks.named('test') {
     delete file('build/generated-snippets')
+    outputs.dir snippetsDir
     useJUnitPlatform()
 }
 
@@ -121,8 +128,6 @@ tasks.register('copyOasToSwagger', Copy) {
     dependsOn tasks.named('addAuthorization')
 }
 
-
-
 tasks.register('addAuthorization', Task) {
     dependsOn 'openapi3'
     doLast {
@@ -140,8 +145,6 @@ tasks.register('addAuthorization', Task) {
         swaggerUIFile.append securitySchemesContent
     }
 }
-
-jar.enabled = false
 
 spotless {
     java {


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #29 

## 📌 작업 내용 및 특이사항

- 배포 워크플로에서 REST Docs API 문서화 작업을 실행할 때 `asciidoctor` 에서 snippet 경로가 존재하지 않아 문서화를 할 수 없는 에러가 발생해서 build.gradle 에 `snippetsDir` 라는 경로를 생성하고 해당 경로를 참조하도록 수정했습니다

## 🔍 참고사항

-

## 📚 기타

-