### PR TITLE
feat: 유저 로그인 기능 구현

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -43,8 +43,8 @@ jobs:
           done
           echo "✅ postgres is ready!"
 
-          echo "${{ secrets.SCHEMA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
-          echo "${{ secrets.DATA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+          echo "${{ secrets.SCHEMA_SQL }}" | base64 --decode | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+          echo "${{ secrets.DATA_SQL }}" | base64 --decode | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
 
       # Gradlew 실행 권한 허용
       - name: Grant Execute Permission for Gradlew

--- a/.github/workflows/develop_pull_request.yml
+++ b/.github/workflows/develop_pull_request.yml
@@ -38,8 +38,8 @@ jobs:
           done
           echo "✅ postgres is ready!"
           
-          echo "${{ secrets.SCHEMA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
-          echo "${{ secrets.DATA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+          echo "${{ secrets.SCHEMA_SQL }}" | base64 --decode | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+          echo "${{ secrets.DATA_SQL }}" | base64 --decode | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
 
       # Gradlew 실행 권한 허용
       - name: Grant Execute Permission for Gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ tasks.register('addAuthorization', Task) {
         def securitySchemesContent =  "  securitySchemes:\n" +
                 "    APIKey:\n" +
                 "      type: apiKey\n" +
-                "      name: JSESSIONID\n" +
+                "      name: SESSION\n" +
                 "      in: cookie\n" +
                 "security:\n" +
                 "  - APIKey: []  # Apply the security scheme here"

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -100,6 +100,8 @@ Content-Type: application/json
 | 공통 | 500 | INTERNAL_SERVER_ERROR | E500_001 | 서버 측에서 처리하지 못한 예외가 발생하면 모든 api 요청에 대해 공통적으로 반환됨.
 |===
 
+
+
 ==  회원
 
 === **1. 이메일 중복 확인**
@@ -161,3 +163,20 @@ include::{snippetsDir}/emailCodeVerification/1/http-response.adoc[]
 include::{snippetsDir}/emailCodeVerification/1/response-fields.adoc[]
 
 
+== 인증/인가
+
+=== **1. 유저 로그인**
+
+유저 로그인 api 입니다. (이메일, 패스워드)
+
+=== Request
+include::{snippetsDir}/loginUser/1/http-request.adoc[]
+
+== 성공 Response
+include::{snippetsDir}/loginUser/1/http-response.adoc[]
+
+== Response Body Fields
+include::{snippetsDir}/loginUser/1/response-fields.adoc[]
+
+== 실패 Response
+include::{snippetsDir}/loginUser/2/http-response.adoc[]

--- a/src/main/java/com/ftm/server/adapter/controller/auth/UserLoginController.java
+++ b/src/main/java/com/ftm/server/adapter/controller/auth/UserLoginController.java
@@ -1,0 +1,37 @@
+package com.ftm.server.adapter.controller.auth;
+
+import com.ftm.server.adapter.dto.request.UserLoginRequest;
+import com.ftm.server.adapter.dto.response.UserLoginResponse;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import com.ftm.server.domain.dto.command.UserLoginCommand;
+import com.ftm.server.domain.usecase.auth.UserLoginUseCase;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserLoginController {
+
+    private final UserLoginUseCase loginUseCase;
+
+    @PostMapping("/api/auth/login")
+    public ResponseEntity<ApiResponse<UserLoginResponse>> login(
+            @RequestBody UserLoginRequest request,
+            HttpServletRequest req,
+            HttpServletResponse res) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(
+                        ApiResponse.success(
+                                SuccessResponseCode.OK,
+                                UserLoginResponse.from(
+                                        loginUseCase.login(
+                                                UserLoginCommand.from(request), req, res))));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/ftm/server/adapter/dto/request/UserLoginRequest.java
@@ -1,0 +1,12 @@
+package com.ftm.server.adapter.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserLoginRequest {
+
+    private final String email;
+    private final String password;
+}

--- a/src/main/java/com/ftm/server/adapter/dto/response/UserLoginResponse.java
+++ b/src/main/java/com/ftm/server/adapter/dto/response/UserLoginResponse.java
@@ -1,0 +1,32 @@
+package com.ftm.server.adapter.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ftm.server.domain.dto.vo.UserSummaryVo;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class UserLoginResponse {
+
+    private final Long id;
+    private final String nickname;
+    private final String profileImageUrl;
+    private final String mildLevelName;
+    private final String spicyLevelName;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING)
+    private final LocalDateTime loginTime;
+
+    UserLoginResponse(UserSummaryVo userSummaryVo) {
+        this.id = userSummaryVo.getId();
+        this.nickname = userSummaryVo.getNickname();
+        this.profileImageUrl = userSummaryVo.getProfileImageUrl();
+        this.mildLevelName = userSummaryVo.getMildLevelName();
+        this.spicyLevelName = userSummaryVo.getSpicyLevelName();
+        this.loginTime = LocalDateTime.now();
+    }
+
+    public static UserLoginResponse from(UserSummaryVo userSummaryVo) {
+        return new UserLoginResponse(userSummaryVo);
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/gateway/AuthenticationGateway.java
+++ b/src/main/java/com/ftm/server/adapter/gateway/AuthenticationGateway.java
@@ -1,0 +1,19 @@
+package com.ftm.server.adapter.gateway;
+
+import com.ftm.server.domain.dto.command.UserLoginCommand;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+
+/** 시큐리티 인증 관련 작업 Gateway */
+public interface AuthenticationGateway {
+
+    // 일반 유저 인증 객체 생성
+    Authentication createAuthenticationFromCredentials(UserLoginCommand command);
+
+    // 인증 세션 등록 (시큐리티 컨텍스트 저장)
+    void saveAuthenticatedSession(
+            Authentication authentication,
+            HttpServletRequest request,
+            HttpServletResponse response);
+}

--- a/src/main/java/com/ftm/server/adapter/gateway/repository/UserImageRepository.java
+++ b/src/main/java/com/ftm/server/adapter/gateway/repository/UserImageRepository.java
@@ -1,0 +1,10 @@
+package com.ftm.server.adapter.gateway.repository;
+
+import com.ftm.server.entity.entities.UserImage;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserImageRepository extends JpaRepository<UserImage, Long> {
+
+    Optional<UserImage> findByUserId(Long userId);
+}

--- a/src/main/java/com/ftm/server/adapter/gateway/repository/UserRepository.java
+++ b/src/main/java/com/ftm/server/adapter/gateway/repository/UserRepository.java
@@ -1,9 +1,12 @@
 package com.ftm.server.adapter.gateway.repository;
 
 import com.ftm.server.entity.entities.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Boolean existsByEmail(String email);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/ftm/server/common/response/enums/ErrorResponseCode.java
+++ b/src/main/java/com/ftm/server/common/response/enums/ErrorResponseCode.java
@@ -12,6 +12,7 @@ public enum ErrorResponseCode {
 
     // 401번
     NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "E401_001", "인증되지 않은 사용자입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "E401_002", "인증에 실패하였습니다."),
 
     // 403번
     NOT_AUTHORIZATION(HttpStatus.FORBIDDEN, "E403_001", "인증된 사용자이나 해당 자원에 대한 접근 권한이 없습니다."),

--- a/src/main/java/com/ftm/server/domain/dto/command/UserLoginCommand.java
+++ b/src/main/java/com/ftm/server/domain/dto/command/UserLoginCommand.java
@@ -1,0 +1,20 @@
+package com.ftm.server.domain.dto.command;
+
+import com.ftm.server.adapter.dto.request.UserLoginRequest;
+import lombok.Getter;
+
+@Getter
+public class UserLoginCommand {
+
+    private final String email;
+    private final String password;
+
+    private UserLoginCommand(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public static UserLoginCommand from(UserLoginRequest request) {
+        return new UserLoginCommand(request.getEmail(), request.getPassword());
+    }
+}

--- a/src/main/java/com/ftm/server/domain/dto/query/FindByIdQuery.java
+++ b/src/main/java/com/ftm/server/domain/dto/query/FindByIdQuery.java
@@ -1,0 +1,17 @@
+package com.ftm.server.domain.dto.query;
+
+import lombok.Getter;
+
+@Getter
+public class FindByIdQuery {
+
+    private final Long id;
+
+    private FindByIdQuery(Long id) {
+        this.id = id;
+    }
+
+    public static FindByIdQuery of(Long id) {
+        return new FindByIdQuery(id);
+    }
+}

--- a/src/main/java/com/ftm/server/domain/dto/query/FindByUserIdQuery.java
+++ b/src/main/java/com/ftm/server/domain/dto/query/FindByUserIdQuery.java
@@ -1,0 +1,17 @@
+package com.ftm.server.domain.dto.query;
+
+import lombok.Getter;
+
+@Getter
+public class FindByUserIdQuery {
+
+    private final Long userId;
+
+    private FindByUserIdQuery(Long userId) {
+        this.userId = userId;
+    }
+
+    public static FindByUserIdQuery of(Long userId) {
+        return new FindByUserIdQuery(userId);
+    }
+}

--- a/src/main/java/com/ftm/server/domain/dto/vo/UserSummaryVo.java
+++ b/src/main/java/com/ftm/server/domain/dto/vo/UserSummaryVo.java
@@ -1,0 +1,28 @@
+package com.ftm.server.domain.dto.vo;
+
+import com.ftm.server.entity.entities.GroomingLevel;
+import com.ftm.server.entity.entities.User;
+import com.ftm.server.entity.entities.UserImage;
+import lombok.Getter;
+
+@Getter
+public class UserSummaryVo {
+
+    private final Long id;
+    private final String nickname;
+    private final String profileImageUrl;
+    private final String mildLevelName;
+    private final String spicyLevelName;
+
+    private UserSummaryVo(User user, UserImage userImage, GroomingLevel groomingLevel) {
+        this.id = user.getId();
+        this.nickname = user.getNickname();
+        this.profileImageUrl = userImage.getObjectKey(); // TODO: 추후 CDN 주소 + getObjectKey() 로 변경해야함
+        this.mildLevelName = groomingLevel.getMildLevelName();
+        this.spicyLevelName = groomingLevel.getSpicyLevelName();
+    }
+
+    public static UserSummaryVo of(User user, UserImage userImage) {
+        return new UserSummaryVo(user, userImage, user.getGroomingLevel());
+    }
+}

--- a/src/main/java/com/ftm/server/domain/service/UserImageService.java
+++ b/src/main/java/com/ftm/server/domain/service/UserImageService.java
@@ -1,0 +1,20 @@
+package com.ftm.server.domain.service;
+
+import com.ftm.server.adapter.gateway.repository.UserImageRepository;
+import com.ftm.server.domain.dto.query.FindByUserIdQuery;
+import com.ftm.server.entity.entities.UserImage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserImageService {
+
+    private final UserImageRepository userImageRepository;
+
+    public UserImage queryUserImageByUserId(FindByUserIdQuery query) {
+        return userImageRepository
+                .findByUserId(query.getUserId())
+                .orElseThrow(() -> new RuntimeException(""));
+    }
+}

--- a/src/main/java/com/ftm/server/domain/service/UserService.java
+++ b/src/main/java/com/ftm/server/domain/service/UserService.java
@@ -1,20 +1,27 @@
 package com.ftm.server.domain.service;
 
 import com.ftm.server.adapter.gateway.repository.UserRepository;
+import com.ftm.server.common.exception.CustomException;
 import com.ftm.server.domain.dto.query.FindByEmailQuery;
+import com.ftm.server.domain.dto.query.FindByIdQuery;
 import com.ftm.server.domain.dto.vo.EmailDuplicationVo;
+import com.ftm.server.entity.entities.User;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class UserService {
 
     private final UserRepository userRepository;
 
     public EmailDuplicationVo isEmailDuplicated(FindByEmailQuery query) {
         return EmailDuplicationVo.of(userRepository.existsByEmail(query.getEmail()));
+    }
+
+    public User queryUser(FindByIdQuery query) {
+        return userRepository
+                .findById(query.getId())
+                .orElseThrow(() -> CustomException.USER_NOT_FOUND);
     }
 }

--- a/src/main/java/com/ftm/server/domain/usecase/auth/UserLoginUseCase.java
+++ b/src/main/java/com/ftm/server/domain/usecase/auth/UserLoginUseCase.java
@@ -1,0 +1,56 @@
+package com.ftm.server.domain.usecase.auth;
+
+import com.ftm.server.adapter.gateway.AuthenticationGateway;
+import com.ftm.server.common.annotation.UseCase;
+import com.ftm.server.common.exception.CustomException;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.dto.command.UserLoginCommand;
+import com.ftm.server.domain.dto.query.FindByIdQuery;
+import com.ftm.server.domain.dto.query.FindByUserIdQuery;
+import com.ftm.server.domain.dto.vo.UserSummaryVo;
+import com.ftm.server.domain.service.UserImageService;
+import com.ftm.server.domain.service.UserService;
+import com.ftm.server.entity.entities.User;
+import com.ftm.server.entity.entities.UserImage;
+import com.ftm.server.infrastructure.security.UserPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class UserLoginUseCase {
+
+    private final AuthenticationGateway securityAuthenticateGateway;
+    private final UserService userService;
+    private final UserImageService userImageService;
+
+    @Transactional
+    public UserSummaryVo login(
+            UserLoginCommand command, HttpServletRequest req, HttpServletResponse res) {
+
+        // 인증을 수행하고 인증 객체 생성 (실패 시 예외 발생)
+        Authentication auth = createAuthenticationOrThrow(command);
+        UserPrincipal userPrincipal = (UserPrincipal) auth.getPrincipal();
+
+        User user = userService.queryUser(FindByIdQuery.of(userPrincipal.getId()));
+        UserImage userImage =
+                userImageService.queryUserImageByUserId(FindByUserIdQuery.of(user.getId()));
+
+        // 인증 세션 등록 (시큐리티 컨텍스트 등록)
+        securityAuthenticateGateway.saveAuthenticatedSession(auth, req, res);
+
+        return UserSummaryVo.of(user, userImage);
+    }
+
+    private Authentication createAuthenticationOrThrow(UserLoginCommand command) {
+        try {
+            return securityAuthenticateGateway.createAuthenticationFromCredentials(command);
+        } catch (AuthenticationException ex) {
+            throw new CustomException(ErrorResponseCode.INVALID_CREDENTIALS);
+        }
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/redis/RedisConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/redis/RedisConfig.java
@@ -15,7 +15,7 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
-@EnableRedisHttpSession
+@EnableRedisHttpSession(redisNamespace = "ftm:session", maxInactiveIntervalInSeconds = 3600)
 @EnableCaching
 @Configuration
 @RequiredArgsConstructor

--- a/src/main/java/com/ftm/server/infrastructure/security/AuthenticationService.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/AuthenticationService.java
@@ -1,0 +1,49 @@
+package com.ftm.server.infrastructure.security;
+
+import com.ftm.server.adapter.gateway.AuthenticationGateway;
+import com.ftm.server.common.annotation.InfraService;
+import com.ftm.server.domain.dto.command.UserLoginCommand;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.SecurityContextRepository;
+
+@Slf4j
+@InfraService
+@RequiredArgsConstructor
+public class AuthenticationService implements AuthenticationGateway {
+
+    private final AuthenticationManager authenticationManager;
+    private final SecurityContextRepository securityContextRepository;
+
+    @Override
+    public Authentication createAuthenticationFromCredentials(UserLoginCommand command)
+            throws AuthenticationException {
+        // 인증 토큰 생성 (입력받은 이메일과 비밀번호로 인증 시도용 토큰 생성)
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(command.getEmail(), command.getPassword());
+
+        // 인증 수행 (UserPrincipalService 호출, PasswordEncoder 비밀번호 검증 포함)
+        return authenticationManager.authenticate(token);
+    }
+
+    @Override
+    public void saveAuthenticatedSession(
+            Authentication authentication,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        // 시큐리티 컨텍스트 생성
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+
+        // 생성한 시큐리티 컨텍스트를 Redis 세션에 저장
+        securityContextRepository.saveContext(context, request, response);
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -7,17 +7,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
-@EnableWebSecurity(debug = true)
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -44,7 +49,7 @@ public class SecurityConfig {
     private static final String[] GET_ANONYMOUS_MATCHERS = {"/api/users/email/duplication"};
 
     private static final String[] POST_ANONYMOUS_MATCHERS = {
-        "/api/users/email/authentication", "/api/users/email/authentication/code"
+        "/api/users/email/authentication", "/api/users/email/authentication/code", "/api/auth/login"
     };
 
     private static final String[] ANONYMOUS_MATCHERS = {"/docs/**"};
@@ -67,6 +72,9 @@ public class SecurityConfig {
                                         .migrateSession() // 세션 고정 보호
                                         .maximumSessions(1) // 동시 로그인 1개 제한
                                         .maxSessionsPreventsLogin(false)) // 기존 세션 만료 후 새 로그인 허용
+                // 시큐리티 컨텍스트 레포지토리 등록 (시큐리티 6.x 이상부터는 시큐리티가 자동으로 컨텍스트에 로드/저장해주지 않기 때문에 명시해줘야함)
+                .securityContext(
+                        context -> context.securityContextRepository(securityContextRepository()))
                 // 예외 핸들링
                 .exceptionHandling(
                         exception ->
@@ -101,6 +109,23 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // Spring Security 6 이상에서는 세션 기반 인증 유지를 위해 SecurityContextRepository 설정이 필요
+    // HttpSession 기반 저장소를 통해 로그인 상태를 세션(Redis)에 자동 저장 및 복원
+    @Bean
+    public SecurityContextRepository securityContextRepository() {
+        return new HttpSessionSecurityContextRepository();
+    }
+
+    // 시큐리티 인증을 관리하는 AuthenticationManager 설정
+    @Bean
+    public AuthenticationManager authenticationManager(UserPrincipalService userPrincipalService) {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userPrincipalService);
+        provider.setPasswordEncoder(passwordEncoder());
+
+        return new ProviderManager(provider);
     }
 
     // CORS 설정

--- a/src/main/java/com/ftm/server/infrastructure/security/UserPrincipal.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/UserPrincipal.java
@@ -1,0 +1,46 @@
+package com.ftm.server.infrastructure.security;
+
+import com.ftm.server.entity.entities.User;
+import com.ftm.server.entity.enums.UserRole;
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/** 인증된 유저 시큐리티 객체 */
+@Getter
+public class UserPrincipal implements UserDetails {
+
+    private final Long id;
+    private final String email;
+    private final String password;
+    private final UserRole role;
+
+    private UserPrincipal(User user) {
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.password = user.getPassword();
+        this.role = user.getRole();
+    }
+
+    public static UserPrincipal of(User user) {
+        return new UserPrincipal(user);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + this.role.name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/security/UserPrincipalService.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/UserPrincipalService.java
@@ -1,0 +1,32 @@
+package com.ftm.server.infrastructure.security;
+
+import com.ftm.server.adapter.gateway.repository.UserRepository;
+import com.ftm.server.common.annotation.InfraService;
+import com.ftm.server.common.exception.CustomException;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.entity.entities.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+/** 시큐리티에서 유저 인증을 수행하고 컨텍스트에 저장할 인증 객체를 생성하는 서비스 */
+@InfraService
+@RequiredArgsConstructor
+public class UserPrincipalService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User saved =
+                userRepository.findByEmail(email).orElseThrow(() -> CustomException.USER_NOT_FOUND);
+
+        // 탈퇴한 회원인 경우 인증 실패 예외 처리
+        if (saved.getIsDeleted() && saved.getDeletedAt() != null) {
+            throw new CustomException(ErrorResponseCode.INVALID_CREDENTIALS);
+        }
+
+        return UserPrincipal.of(saved);
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/security/handler/PermissionDeniedHandler.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/handler/PermissionDeniedHandler.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
-import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 import org.springframework.stereotype.Component;
 
 /** 인증은 되었지만 접근 권한이 없는 경우 예외처리하는 핸들러 */
@@ -27,7 +26,5 @@ public class PermissionDeniedHandler implements AccessDeniedHandler {
             throws IOException, ServletException {
         securityResponseHandler.sendResponse(
                 response, ApiResponse.fail(ErrorResponseCode.NOT_AUTHORIZATION));
-
-        SecurityContextPersistenceFilter filter = new SecurityContextPersistenceFilter();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,9 +9,6 @@ spring:
       - storage
       - security
 
-  session:
-    timeout: 1800 # 30분
-
   mail:
     host: smtp.gmail.com
     port: 587

--- a/src/test/java/com/ftm/server/auth/UserLoginTest.java
+++ b/src/test/java/com/ftm/server/auth/UserLoginTest.java
@@ -1,0 +1,124 @@
+package com.ftm.server.auth;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.dto.request.UserLoginRequest;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class UserLoginTest extends BaseTest {
+
+    private final List<FieldDescriptor> requestFieldLoginUser =
+            List.of(
+                    fieldWithPath("email").type(STRING).description("이메일"),
+                    fieldWithPath("password").type(STRING).description("패스워드"));
+
+    private final List<FieldDescriptor> responseFieldLoginUser =
+            List.of(
+                    fieldWithPath("status").type(NUMBER).description("응답 상태"),
+                    fieldWithPath("code").type(STRING).description("상태 코드"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data").type(OBJECT).optional().description("data"),
+                    fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
+                    fieldWithPath("data.nickname").type(STRING).description("유저 닉네임"),
+                    fieldWithPath("data.profileImageUrl")
+                            .type(STRING)
+                            .description("유저 프로필 이미지 URL"),
+                    fieldWithPath("data.mildLevelName").type(STRING).description("순한맛 그루밍 레벨 이름"),
+                    fieldWithPath("data.spicyLevelName").type(STRING).description("매운맛 그루밍 레벨 이름"),
+                    fieldWithPath("data.loginTime").type(STRING).description("로그인 시간"));
+
+    private ResultActions getResultActions(UserLoginRequest request) throws Exception {
+        return mockMvc.perform(
+                RestDocumentationRequestBuilders.post("/api/auth/login")
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .content(mapper.writeValueAsString(request)));
+    }
+
+    private RestDocumentationResultHandler getDocument(Integer identifier) {
+        return document(
+                "loginUser/" + identifier,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint(), getModifiedHeader()),
+                requestFields(requestFieldLoginUser),
+                responseHeaders(
+                        headerWithName("Set-Cookie")
+                                .description("세션 ID를 담고 있는 쿠키 (SESSION), 만료 시간: 1시간")
+                                .optional()),
+                responseFields(responseFieldLoginUser),
+                resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("인증/인가")
+                                .summary("유저 로그인 api")
+                                .description("유저 로그인 api 입니다.")
+                                .responseFields(responseFieldLoginUser)
+                                .build()));
+    }
+
+    @Test
+    @Transactional
+    void 유저_로그인_성공() throws Exception {
+        // given
+        String email = "test@gmail.com";
+        String password = "test1234!";
+        UserLoginRequest request = new UserLoginRequest(email, password);
+
+        // when
+        ResultActions resultActions = getResultActions(request);
+        MvcResult result = resultActions.andReturn();
+
+        // 세션 쿠키 수동 추가 (문서화 통과용)
+        result.getResponse().addHeader("Set-Cookie", "SESSION=mock-session-id; Path=/; HttpOnly");
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", Matchers.containsString("SESSION")))
+                .andDo(print());
+
+        // documentation
+        resultActions.andDo(getDocument(1));
+    }
+
+    @Test
+    @Transactional
+    void 유저_로그인_실패() throws Exception {
+        // given
+        String email = "test@gmail.com";
+        String password = "test12345!";
+        UserLoginRequest request = new UserLoginRequest(email, password);
+
+        // when
+        ResultActions resultActions = getResultActions(request);
+
+        // then
+        resultActions
+                .andExpect(
+                        status().is(ErrorResponseCode.INVALID_CREDENTIALS.getHttpStatus().value()))
+                .andExpect(jsonPath("code").value(ErrorResponseCode.INVALID_CREDENTIALS.getCode()))
+                .andDo(print());
+
+        // documentation
+        resultActions.andDo(getDocument(2));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #31 

## 📌 작업 내용 및 특이사항

- 유저 로그인 기능 구현했습니다 (이메일, 패스워드 기반)
- 스프링 시큐리티를 사용해서 인증 로직과 스프링 세션 + 레디스를 적용해 구현했습니다
- 시큐리티 6.x 이상부터는 시큐리티 컨텍스트가 자동으로 컨텍스트를 로드, 저장하는 과정을 지원하지 않는다고 해서 SecurityConfig 파일에 securityContext() 를 통해 명시해줬습니다

## 🔍 참고사항

- 유저 로그인 테스트 시 등록된 유저 정보가 필요한데 아직 유저를 등록하는 로직이 존재하지 않아서 CICD 환경에 임의 테스트 유저를 등록하도록 했습니다
- 유저 로그인 테스트에서 유저 이미지 정보도 필요해서 테스트 유저가 등록될 때 함께 테스트 유저 이미지도 등록되도록 Trigger 설정했습니다
- Redis에 세션이 등록될 때 `ftm:session` 형식으로 등록되도록 수정해줬습니다
- 스프링 세션과 레디스를 사용할 때 자동으로 생성되는 세션 쿠키 이름은 `SESSION` 이라 이에 맞게 문서화 내용도 수정해줬습니다

## 📚 기타

- 이메일 로그인 시 요청한 데이터가 이메일 형식인지 validation 하지 않고 구현했는데 혹시 로그인 로직에서도 이메일 형식인지 검증하고 그에 맞는 에러 응답을 처리하도록 하는게 더 알맞을까요 ?

<br/>


### [ 트러블 슈팅 ] 

- 임의 테스트 유저를 등록할 때 암호화된 패스워드 값에 `$` 기호가 변수로 인식되면서 잘못된 값이 DB에 등록되는 에러가 발생해 secrets SCHEMA_SQL , DATA_SQL 정보를 base64 로 인코드해 저장하고 워크플로에서 decode 하도록 수정했습니다 (2da8473809b1c98b3a124cde208be1d598df3038)
- 추후 유저 등록 로직이 구성되면 다시 수정 예정
