### PR TITLE
docs : Add Response Header To API Documentation(#61)

### DIFF
--- a/src/docs/asciidoc/user-api.adoc
+++ b/src/docs/asciidoc/user-api.adoc
@@ -111,6 +111,9 @@ include::{snippetsDir}/socialUserSignUp/1/request-fields.adoc[]
 ==== 성공 Response
 include::{snippetsDir}/socialUserSignUp/1/http-response.adoc[]
 
+==== Response Headers
+include::{snippetsDir}/socialUserSignUp/1/response-headers.adoc[]
+
 ==== Response Body Fields
 include::{snippetsDir}/socialUserSignUp/1/response-fields.adoc[]
 

--- a/src/test/java/com/ftm/server/user/SocialUserSignupTest.java
+++ b/src/test/java/com/ftm/server/user/SocialUserSignupTest.java
@@ -100,7 +100,8 @@ public class SocialUserSignupTest extends BaseTest {
                 requestFields(requestFieldDescriptors),
                 responseHeaders(
                         headerWithName("Set-Cookie")
-                                .description("세션 ID를 담고 있는 쿠키 (SESSION), 만료 시간: 1시간")
+                                .description(
+                                        "로그인 성공 시 발급되는 세션 쿠키 (만료 시간: 1시간, Value: SESSION=session-id 형태)")
                                 .optional()),
                 resource(
                         ResourceSnippetParameters.builder()


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #65

## 📌 작업 내용 및 특이사항

- 소셜 로그인 회원가입 api 문서화에서 response header 누락된 것 추가해줬습니다. 

## 🔍 참고사항

-

## 📚 기타

-