### PR TITLE
chore: cors 경로에 https 로컬 클라이언트 경로 추가

### DIFF
--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                     "http://localhost:8080", // 로컬 환경 서버 도메인
                     "https://dev-api.fittheman.site", // 개발 환경 서버 도메인
                     "http://localhost:3000", // 로컬 환경 클라이언트 도메인
+                    "https://localhost:3000", // 로컬 환경 https 클라이언트 도메인
                     "https://fittheman.site"); // 개발 환경 클라이언트 도메인
 
     private static final String[] GET_ANONYMOUS_MATCHERS = {


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #67 

## 📌 작업 내용 및 특이사항

- 로컬 클라이언트 쿠키 테스트를 위해 cors 허용 경로에 https 로컬 클라이언트 경로 추가했습니다

## 🔍 참고사항

-

## 📚 기타

-