### PR TITLE
fix: 개발환경 세션 쿠키 cross-site 요청 이슈 해결

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,3 +6,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+
+server:
+  servlet:
+    session:
+      cookie:
+        name: SESSION
+        same-site: none
+        secure: true


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #69 

## 📌 작업 내용 및 특이사항

- 개발 서버에서 세션 쿠키가 `기본값(SameSite=Lax)`으로 설정되어 있어, 클라이언트에서 cross-site 요청을 보낼 때 쿠키가 전달되지 않는 문제가 발생
- `SameSite=Lax` 옵션은 `GET` 요청일 땐 쿠키를 요청할 수 있지만, `POST` 같은 요청에는 브라우저가 보안상의 이유(CSRF 공격)로 자동으로 쿠키를 전달할 수 없도록 제한한다고 함
- `dev profile` 의 세션 쿠키 `same-site `옵션을 `none` 으로 설정하고 자동으로 `secure=true` 가 적용되면서 https 요청에만 쿠키가 전송되도록 설정되 보안도 유지하면서 cross-site 요청에도 세션 쿠키가 정상적으로 작동하도록 개션

## 🔍 참고사항

- `CookieConfig` 클래스를 만들어 `CookieSameSiteSupplier`를 빈으로 등록하고, 활성화된 프로필에 따라 세션 쿠키의 `SameSite` 옵션을 분기 처리하려 했지만
테스트 결과 해당 설정이 적용되지 않았고, 확인해보니 `CookieSameSiteSupplier`는 서블릿 컨테이너(Tomcat 등)가 HttpServletResponse.addCookie(...) 방식으로 쿠키를 생성할 때만 개입할 수 있기 때문에,
`Spring Session`처럼 Set-Cookie 헤더를 직접 문자열로 추가하는 방식(response.addHeader(...))에서는 동작하지 않는 것으로 확인되었습니다.
- 그래서 `application-dev.yml` 파일에 설정을 직접 명시하는 방식으로 변경해 테스트 해봤고 이 경우는 설정이 정상적으로 반영되는걸 확인했습니다.
- 실제 개발 서버로 배포된 이후 실제 클라이언트로 재테스트 해봐야할 것 같습니다

## 📚 기타

-