### PR TITLE
chore: 개발 환경에서 세션 쿠키 도메인 설정, CORS 허용 메소드 추가

### DIFF
--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                     HttpMethod.PUT,
                     HttpMethod.PATCH,
                     HttpMethod.DELETE,
+                    HttpMethod.OPTIONS,
                     HttpMethod.HEAD);
 
     // CORS 에서 허용할 도메인 목록

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,3 +14,4 @@ server:
         name: SESSION
         same-site: none
         secure: true
+        domain: .fittheman.site


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #71 

## 📌 작업 내용 및 특이사항

- 개발 환경에서 세션 쿠키를 발급할 때 도메인 정보를 설정해주어야, 브라우저가 이후 요청에서 해당 쿠키를 제대로 포함해 서버로 전송할 수 있다고 하여 도메인 설정 추가
- CORS 설정에서 허용 HttpMethod 에 OPTIONS 추가

## 🔍 참고사항

-

## 📚 기타

-