### PR TITLE
fix: 불필요한 세션이 생성되는 버그 해결

### DIFF
--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -82,6 +82,8 @@ public class SecurityConfig {
                                         .migrateSession() // 세션 고정 보호
                                         .maximumSessions(1) // 동시 로그인 1개 제한
                                         .maxSessionsPreventsLogin(false)) // 기존 세션 만료 후 새 로그인 허용
+                // 인증되지 않은 요청에 대한 요청을 세션에 저장하지 않도록 하기 위한 설정
+                .requestCache(AbstractHttpConfigurer::disable)
                 // 시큐리티 컨텍스트 레포지토리 등록 (시큐리티 6.x 이상부터는 시큐리티가 자동으로 컨텍스트에 로드/저장해주지 않기 때문에 명시해줘야함)
                 .securityContext(
                         context -> context.securityContextRepository(securityContextRepository()))
@@ -105,8 +107,6 @@ public class SecurityConfig {
                                     .permitAll()
                                     .requestMatchers(HttpMethod.POST, POST_ANONYMOUS_MATCHERS)
                                     .permitAll();
-
-                            // TODO: 요청 허용 특정 API 추가 (회원가입, 로그인 등)
 
                             // 그 외 모든 요청은 인증 필요
                             authorize.anyRequest().authenticated();


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #75 

## 📌 작업 내용 및 특이사항

- 카카오 로그인 API에서 클라이언트가 카카오 서버로부터 `authorization code`를 발급받고 `/api/auth/kakao/callback` 경로로 리다이렉트 될 때 서버에 세션이 생성되는 현상을 발견했습니다
- 찾아보니 이는 스프링 시큐리티의 기본 동작으로, 인증되지 않은 사용자가 보호된 경로(인증이 필요한 경로, permitAll() 로 등록한 경로를 제외한 모든 경로)에 접근하면 추후 인증된 후 원래 요청으로 리다이렉트하기 위해 해당 요청 정보를 세션에 임시로 저장해둔다고 합니다
- 이런 증상은 불필요한 세션을 생성하면서 성능 저하, 리소스 낭비 문제가 발생할 수 있다고 판단하고, 불필요한 세션이 생성되지 않도록 스프링 시큐리티 `requestCache()` 설정을 `disabled` 처리해 비활성화 시켰습니다

## 🔍 참고사항

-

## 📚 기타

-