### PR TITLE
feat, refactor: Caffeine Cache 적용 (redis -> caffeine)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Caffeine Cache
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     // AWS SDK
     implementation 'software.amazon.awssdk:s3:2.20.140' // 최신 버전 확인 후 적용
     implementation 'software.amazon.awssdk:auth:2.20.140' // IAM 인증 관련
@@ -77,7 +80,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
 }
 
 jar.enabled = false

--- a/src/main/java/com/ftm/server/infrastructure/cache/CaffeineCacheConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/cache/CaffeineCacheConfig.java
@@ -1,0 +1,21 @@
+package com.ftm.server.infrastructure.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CaffeineCacheConfig {
+
+    @Bean
+    public CaffeineCacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+        manager.setAllowNullValues(false); // null 값 저장하지 않음
+        manager.setCaffeine(Caffeine.newBuilder().maximumSize(100).recordStats());
+
+        return manager;
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/redis/RedisConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/redis/RedisConfig.java
@@ -1,22 +1,16 @@
 package com.ftm.server.infrastructure.redis;
 
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 @EnableRedisHttpSession(redisNamespace = "ftm:session", maxInactiveIntervalInSeconds = 3600)
-@EnableCaching
 @Configuration
 @RequiredArgsConstructor
 public class RedisConfig {
@@ -45,21 +39,5 @@ public class RedisConfig {
 
         template.afterPropertiesSet();
         return template;
-    }
-
-    // Redis Caching
-    @Bean
-    public RedisCacheManager redisCacheManager(RedisConnectionFactory factory) {
-        RedisCacheConfiguration cacheConfiguration =
-                RedisCacheConfiguration.defaultCacheConfig()
-                        .entryTtl(Duration.ofMinutes(30)) // 기본 캐시 만료시간 30분
-                        .serializeKeysWith(
-                                RedisSerializationContext.SerializationPair.fromSerializer(
-                                        new StringRedisSerializer()))
-                        .serializeValuesWith(
-                                RedisSerializationContext.SerializationPair.fromSerializer(
-                                        new GenericJackson2JsonRedisSerializer()));
-
-        return RedisCacheManager.builder(factory).cacheDefaults(cacheConfiguration).build();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #90 

## 📌 작업 내용 및 특이사항

- 기존 `Redis` 로 캐시를 관리하던 방법에서 로컬 캐시 `Caffeine` 로 캐시를 관리하는 방법으로 변경했습니다
- `Redis`를 캐싱 전략으로 사용하면 분산 캐시로써 여러 서버 인스턴스 간에 데이터를 공유할 수 있고, 서버가 수평 확장되거나 다중 인스턴스 환경에서 동일한 캐시 데이터를 사용할 수 있도록 하여 데이터 일관성을 보장하고, 중앙 집중식 캐시 관리가 가능하다는 이점이 있지만, Redis는 네트워크를 통해 접근하기 때문에 로컬 메모리 기반 캐시보다 상대적으로 응답 속도가 느리고, Redis 서버 자체의 운영과 유지 관리가 필요하다는 단점이 존재합니다
- 또한, 현재 서버를 단일 인스턴스로 운영하고 있어, 인스턴스 간 캐시를 공유해야 하는 상황이 아니기 때문에 분산 캐시의 이점보다는 각 인스턴스 내부에서 빠르게 데이터를 조회할 수 있는 로컬 캐시가 적합하다 판단해 캐시 전략을 Redis에서 Caffeine으로 전환하게 되었습니다
- 또한, Redis 를 세션 저장소로 사용하고 있기 때문에 역할을 분리하고자 캐시 전략을 Caffeine 으로 변경했습니다

## 🔍 참고사항

-

## 📚 기타

-