### PR TITLE
refactor: 유저픽 게시글 저장 응답 데이터 추가 및 리팩토링

### DIFF
--- a/src/docs/asciidoc/post-api.adoc
+++ b/src/docs/asciidoc/post-api.adoc
@@ -19,6 +19,9 @@ include::{snippetsDir}/savePost/1/request-part-data-fields.adoc[]
 ==== 성공 Response
 include::{snippetsDir}/savePost/1/http-response.adoc[]
 
+==== Response Body Fields
+include::{snippetsDir}/savePost/1/response-fields.adoc[]
+
 ==== 실패 Response
 실패 1. 인증되지 않은 유저일 경우
 

--- a/src/main/java/com/ftm/server/adapter/in/web/post/controller/SavePostController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/controller/SavePostController.java
@@ -1,8 +1,10 @@
 package com.ftm.server.adapter.in.web.post.controller;
 
 import com.ftm.server.adapter.in.web.post.dto.request.SavePostRequest;
+import com.ftm.server.adapter.in.web.post.dto.response.SavePostResponse;
 import com.ftm.server.application.command.post.SavePostCommand;
 import com.ftm.server.application.port.in.post.SavePostUseCase;
+import com.ftm.server.application.vo.post.PostInfoVo;
 import com.ftm.server.common.response.ApiResponse;
 import com.ftm.server.common.response.enums.SuccessResponseCode;
 import com.ftm.server.infrastructure.security.UserPrincipal;
@@ -24,17 +26,18 @@ public class SavePostController {
     private final SavePostUseCase savePostUseCase;
 
     @PostMapping("/api/posts")
-    public ResponseEntity<ApiResponse<Void>> savePost(
+    public ResponseEntity<ApiResponse<SavePostResponse>> savePost(
             @RequestPart(value = "data") @Valid SavePostRequest request,
             @RequestPart(value = "postImageFiles", required = false)
                     List<MultipartFile> postImageFiles,
             @RequestPart(value = "productImageFiles", required = false)
                     List<MultipartFile> productImageFiles,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        savePostUseCase.execute(
-                SavePostCommand.from(
-                        userPrincipal.getId(), request, postImageFiles, productImageFiles));
+        PostInfoVo vo =
+                savePostUseCase.execute(
+                        SavePostCommand.from(
+                                userPrincipal.getId(), request, postImageFiles, productImageFiles));
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(SuccessResponseCode.CREATED));
+                .body(ApiResponse.success(SuccessResponseCode.CREATED, SavePostResponse.from(vo)));
     }
 }

--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/SavePostResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/SavePostResponse.java
@@ -1,0 +1,28 @@
+package com.ftm.server.adapter.in.web.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ftm.server.application.vo.post.PostInfoVo;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class SavePostResponse {
+
+    private final Long postId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING)
+    private final LocalDateTime createdAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING)
+    private final LocalDateTime updatedAt;
+
+    private SavePostResponse(PostInfoVo postInfoVo) {
+        this.postId = postInfoVo.getId();
+        this.createdAt = postInfoVo.getCreatedAt();
+        this.updatedAt = postInfoVo.getUpdatedAt();
+    }
+
+    public static SavePostResponse from(PostInfoVo postInfoVo) {
+        return new SavePostResponse(postInfoVo);
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/post/SavePostCommand.java
+++ b/src/main/java/com/ftm/server/application/command/post/SavePostCommand.java
@@ -27,7 +27,7 @@ public class SavePostCommand {
             List<MultipartFile> productImages) {
         this.userId = userId;
         this.title = request.getTitle();
-        this.groomingCategory = getGroomingCategory();
+        this.groomingCategory = request.getGroomingCategory();
         this.hashTags = request.getHashtags().toArray(new HashTag[0]);
         this.content = request.getContent();
         this.postImages = postImages;

--- a/src/main/java/com/ftm/server/application/port/in/post/SavePostUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/post/SavePostUseCase.java
@@ -1,10 +1,11 @@
 package com.ftm.server.application.port.in.post;
 
 import com.ftm.server.application.command.post.SavePostCommand;
+import com.ftm.server.application.vo.post.PostInfoVo;
 import com.ftm.server.common.annotation.UseCase;
 
 @UseCase
 public interface SavePostUseCase {
 
-    void execute(SavePostCommand command);
+    PostInfoVo execute(SavePostCommand command);
 }

--- a/src/main/java/com/ftm/server/application/service/post/SavePostService.java
+++ b/src/main/java/com/ftm/server/application/service/post/SavePostService.java
@@ -11,6 +11,7 @@ import com.ftm.server.application.port.out.s3.S3ImageDeletePort;
 import com.ftm.server.application.port.out.s3.S3PostImageUploadPort;
 import com.ftm.server.application.port.out.s3.S3PostProductImageUploadPort;
 import com.ftm.server.application.port.out.transcation.AfterRollbackExecutorPort;
+import com.ftm.server.application.vo.post.PostInfoVo;
 import com.ftm.server.common.exception.CustomException;
 import com.ftm.server.common.response.enums.ErrorResponseCode;
 import com.ftm.server.domain.entity.Post;
@@ -44,7 +45,7 @@ public class SavePostService implements SavePostUseCase {
 
     @Override
     @Transactional
-    public void execute(SavePostCommand command) {
+    public PostInfoVo execute(SavePostCommand command) {
 
         // 상품, 상품이미지 검증
         validateProductImages(command.getProducts(), command.getProductImages());
@@ -98,6 +99,8 @@ public class SavePostService implements SavePostUseCase {
             postProductImages.add(PostProductImage.createDefault(postProduct.getId()));
         }
         savePostProductImagePort.savePostProductImages(postProductImages);
+
+        return PostInfoVo.from(post);
     }
 
     private void validateProductImages(

--- a/src/main/java/com/ftm/server/application/vo/post/PostInfoVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/PostInfoVo.java
@@ -1,0 +1,41 @@
+package com.ftm.server.application.vo.post;
+
+import com.ftm.server.domain.entity.Post;
+import com.ftm.server.domain.enums.GroomingCategory;
+import com.ftm.server.domain.enums.HashTag;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class PostInfoVo {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final GroomingCategory groomingCategory;
+    private final HashTag[] hashtags;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Boolean isDeleted;
+    private final LocalDateTime deletedAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    private PostInfoVo(Post post) {
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.groomingCategory = post.getGroomingCategory();
+        this.hashtags = post.getHashtags();
+        this.viewCount = post.getViewCount();
+        this.likeCount = post.getLikeCount();
+        this.isDeleted = post.getIsDeleted();
+        this.deletedAt = post.getDeletedAt();
+        this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getUpdatedAt();
+    }
+
+    public static PostInfoVo from(Post post) {
+        return new PostInfoVo(post);
+    }
+}

--- a/src/test/java/com/ftm/server/post/SavePostTest.java
+++ b/src/test/java/com/ftm/server/post/SavePostTest.java
@@ -89,7 +89,10 @@ public class SavePostTest extends BaseTest {
                     fieldWithPath("status").type(NUMBER).description("응답 상태"),
                     fieldWithPath("code").type(STRING).description("상태 코드"),
                     fieldWithPath("message").type(STRING).description("메시지"),
-                    fieldWithPath("data").type(OBJECT).optional().description("응답 데이터"));
+                    fieldWithPath("data").type(OBJECT).optional().description("응답 데이터"),
+                    fieldWithPath("data.postId").type(NUMBER).description("생성된 유저픽 게시글 ID"),
+                    fieldWithPath("data.createdAt").type(STRING).description("게시글 생성 날짜"),
+                    fieldWithPath("data.updatedAt").type(STRING).description("게시글 수정 날짜"));
 
     private ResultActions getResultActions(
             MockHttpSession session,


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #100 

## 📌 작업 내용 및 특이사항

- 유저픽 게시글 저장 로직 리팩토링 진행했습니다
- grooming_category 필드에 null 이 계속 저장되는 버그가 있어서 해결했습니다
- 기존 유저픽 게시글 저장에 성공하면 응답 데이터가 없었는데 저장 성공 시 바로 해당 게시글의 상세 조회로 자연스럽게 넘어가도록 하기 위해 생성된 게시글의 ID를 포함한 응답 데이터를 추가했습니다

## 🔍 참고사항

-

## 📚 기타

-