### PR TITLE
feat : 세션 유효성 검사 api 추가(#102)

### DIFF
--- a/src/docs/asciidoc/auth-api.adoc
+++ b/src/docs/asciidoc/auth-api.adoc
@@ -70,3 +70,23 @@ include::{snippetsDir}/logout/1/response-fields.adoc[]
 
 ==== 실패 Response
 include::{snippetsDir}/logout/2/http-response.adoc[]
+
+
+=== **4. Session 유효성 확인 API**
+
+Session 유효성 확인 api입니다.
+
+==== Request
+include::{snippetsDir}/sessionValidityCheck/1/http-request.adoc[]
+
+==== 성공 Response
+성공 1. 유효한 경우
+include::{snippetsDir}/sessionValidityCheck/1/http-response.adoc[]
+
+성공 2. 유효하지 않은 경우
+include::{snippetsDir}/sessionValidityCheck/2/http-response.adoc[]
+
+==== Response Body Fields
+include::{snippetsDir}/sessionValidityCheck/1/response-fields.adoc[]
+
+

--- a/src/main/java/com/ftm/server/adapter/in/web/auth/controller/SessionValidityCheckController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/auth/controller/SessionValidityCheckController.java
@@ -1,0 +1,34 @@
+package com.ftm.server.adapter.in.web.auth.controller;
+
+import com.ftm.server.adapter.in.web.auth.dto.response.SessionValidityCheckResponse;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SessionValidityCheckController {
+
+    @GetMapping("/api/auth/session/validity")
+    public ResponseEntity<ApiResponse<SessionValidityCheckResponse>> sessionValidationCheck(
+            HttpServletRequest req, HttpServletResponse res) {
+
+        Boolean isValid = true;
+
+        HttpSession session = req.getSession(false); // session 조회
+
+        if (session == null) {
+            isValid = false;
+        }
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(
+                        ApiResponse.success(
+                                SuccessResponseCode.OK, SessionValidityCheckResponse.of(isValid)));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/auth/dto/response/SessionValidityCheckResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/auth/dto/response/SessionValidityCheckResponse.java
@@ -1,0 +1,12 @@
+package com.ftm.server.adapter.in.web.auth.dto.response;
+
+import lombok.Data;
+
+@Data
+public class SessionValidityCheckResponse {
+    private final Boolean isValid;
+
+    public static SessionValidityCheckResponse of(Boolean isValid) {
+        return new SessionValidityCheckResponse(isValid);
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -51,7 +51,10 @@ public class SecurityConfig {
                     "https://fittheman.site"); // 개발 환경 클라이언트 도메인
 
     private static final String[] GET_ANONYMOUS_MATCHERS = {
-        "/api/users/email/duplication", "/api/users/options", "/api/grooming/tests"
+        "/api/users/email/duplication",
+        "/api/users/options",
+        "/api/grooming/tests",
+        "/api/auth/session/validity"
     };
 
     private static final String[] POST_ANONYMOUS_MATCHERS = {

--- a/src/test/java/com/ftm/server/auth/SessionValidationCheckTest.java
+++ b/src/test/java/com/ftm/server/auth/SessionValidationCheckTest.java
@@ -1,0 +1,90 @@
+package com.ftm.server.auth;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.ftm.server.BaseTest;
+import jakarta.servlet.http.Cookie;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class SessionValidationCheckTest extends BaseTest {
+
+    private final List<FieldDescriptor> responseFieldDescriptors =
+            List.of(
+                    fieldWithPath("status").type(NUMBER).description("응답 상태"),
+                    fieldWithPath("code").type(STRING).description("상태 코드"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data").type(OBJECT).optional().description("data"),
+                    fieldWithPath("data.isValid").type(BOOLEAN).description("session 유효성 여부"));
+
+    private ResultActions getResultActions(MockHttpSession session) throws Exception {
+        return mockMvc.perform( // api 실행
+                RestDocumentationRequestBuilders.get("/api/auth/session/validity")
+                        .session(session)
+                        .cookie(new Cookie("SESSION", session.getId())));
+    }
+
+    private RestDocumentationResultHandler getDocument(Integer identifier) {
+        return document(
+                "sessionValidityCheck/" + identifier,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint(), getModifiedHeader()),
+                responseFields(responseFieldDescriptors),
+                resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("인증/인가")
+                                .summary("세션 유효성 확인 api")
+                                .description("세션 유효성 확인 api입니다.")
+                                .responseFields(responseFieldDescriptors)
+                                .build()));
+    }
+
+    @Test
+    @Transactional
+    public void 세션_유효성_성공1() throws Exception {
+        // given
+        MockHttpSession session = createUserAndLogin();
+
+        // when
+        ResultActions resultActions = getResultActions(session);
+
+        // then
+        resultActions.andExpect(status().isOk()).andExpect(jsonPath("data.isValid").value(true));
+        ;
+
+        // documentation
+        resultActions.andDo(getDocument(1));
+    }
+
+    @Test
+    @Transactional
+    public void 세션_유효성_성공2() throws Exception {
+        // given
+        MockHttpSession session = createUserAndLogin();
+        session.invalidate();
+
+        // when
+        ResultActions resultActions = getResultActions(session);
+
+        // then
+        resultActions.andExpect(status().isOk()).andExpect(jsonPath("data.isValid").value(false));
+
+        // documentation
+        resultActions.andDo(getDocument(2));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #102

## 📌 작업 내용 및 특이사항

- session 유효성 검사 api 추가했습니다.
- usecase 따로 두지 않고 controller 단에서 session 확인하고 응답값 반환하도록 했습니다. 
- 현재 로그인이나 세션 유효성 확인 모두 컨트롤러 단에서 세션을 다루고 있는데, 추후에 interface로 만들어서 usecase에서 다루는 것도 고려해보면 좋을 것 같습니다. 
## 🔍 참고사항

-

## 📚 기타

-