### PR TITLE
feat: 유저픽 게시글 상세 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/post-api.adoc
+++ b/src/docs/asciidoc/post-api.adoc
@@ -44,3 +44,27 @@ include::{snippetsDir}/savePost/5/http-response.adoc[]
 실패 5. 이미지 파일 업로드에 실패할 경우
 
 include::{snippetsDir}/savePost/6/http-response.adoc[]
+
+---
+
+=== **2. 게시글 상세 조회**
+
+유저픽 게시글 상세 조회 api 입니다.
+
+==== Request
+include::{snippetsDir}/loadPostDetail/1/http-request.adoc[]
+
+==== Request Path Parameters
+include::{snippetsDir}/loadPostDetail/1/path-parameters.adoc[]
+
+==== 성공 Response
+include::{snippetsDir}/loadPostDetail/1/http-response.adoc[]
+
+==== Response Body Fields
+include::{snippetsDir}/loadPostDetail/1/response-fields.adoc[]
+
+==== 실패 Response
+
+실패 1. 존재하지 않는 게시글이거나, 삭제된 게시글인 경우
+
+include::{snippetsDir}/loadPostDetail/2/http-response.adoc[]

--- a/src/main/java/com/ftm/server/adapter/in/web/post/controller/LoadPostDetailController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/controller/LoadPostDetailController.java
@@ -1,0 +1,29 @@
+package com.ftm.server.adapter.in.web.post.controller;
+
+import com.ftm.server.adapter.in.web.post.dto.response.LoadPostDetailResponse;
+import com.ftm.server.application.port.in.post.LoadPostDetailUseCase;
+import com.ftm.server.application.query.FindByIdQuery;
+import com.ftm.server.application.vo.post.PostDetailVo;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LoadPostDetailController {
+
+    private final LoadPostDetailUseCase loadPostDetailUseCase;
+
+    @GetMapping("/api/posts/{postId}")
+    public ResponseEntity<ApiResponse<?>> loadPostDetail(@PathVariable Long postId) {
+        PostDetailVo vo = loadPostDetailUseCase.execute(FindByIdQuery.of(postId));
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessResponseCode.OK, LoadPostDetailResponse.from(vo)));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/LoadPostDetailResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/LoadPostDetailResponse.java
@@ -1,0 +1,53 @@
+package com.ftm.server.adapter.in.web.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ftm.server.application.vo.post.PostDetailVo;
+import com.ftm.server.domain.enums.GroomingCategory;
+import com.ftm.server.domain.enums.HashTag;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class LoadPostDetailResponse {
+
+    private final Long postId;
+    private final String title;
+    private final String content;
+    private final GroomingCategory groomingCategory;
+    private final List<String> hashTags;
+    private final Integer viewCount;
+    private final Integer likeCount;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING)
+    private final LocalDateTime createdAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING)
+    private final LocalDateTime updatedAt;
+
+    private final List<PostImageResponse> postImages;
+    private final PostWriterResponse writer;
+    private final List<PostProductResponse> postProducts;
+
+    private LoadPostDetailResponse(PostDetailVo postDetailVo) {
+        this.postId = postDetailVo.getPostId();
+        this.title = postDetailVo.getTitle();
+        this.content = postDetailVo.getContent();
+        this.groomingCategory = postDetailVo.getGroomingCategory();
+        this.hashTags = Arrays.stream(postDetailVo.getHashTags()).map(HashTag::getValue).toList();
+        this.viewCount = postDetailVo.getViewCount();
+        this.likeCount = postDetailVo.getLikeCount();
+        this.createdAt = postDetailVo.getCreatedAt();
+        this.updatedAt = postDetailVo.getUpdatedAt();
+        this.postImages =
+                postDetailVo.getPostImages().stream().map(PostImageResponse::from).toList();
+        this.writer = PostWriterResponse.from(postDetailVo.getUser(), postDetailVo.getUserImage());
+        this.postProducts =
+                postDetailVo.getProducts().stream().map(PostProductResponse::from).toList();
+    }
+
+    public static LoadPostDetailResponse from(PostDetailVo postDetailVo) {
+        return new LoadPostDetailResponse(postDetailVo);
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/PostImageResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/PostImageResponse.java
@@ -1,0 +1,22 @@
+package com.ftm.server.adapter.in.web.post.dto.response;
+
+import static com.ftm.server.common.consts.PropertiesHolder.CDN_PATH;
+
+import com.ftm.server.domain.entity.PostImage;
+import lombok.Getter;
+
+@Getter
+public class PostImageResponse {
+
+    private final Long postImageId;
+    private final String imageUrl;
+
+    private PostImageResponse(PostImage postImage) {
+        this.postImageId = postImage.getId();
+        this.imageUrl = CDN_PATH + "/" + postImage.getObjectKey();
+    }
+
+    public static PostImageResponse from(PostImage postImage) {
+        return new PostImageResponse(postImage);
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/PostProductImageResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/PostProductImageResponse.java
@@ -1,0 +1,22 @@
+package com.ftm.server.adapter.in.web.post.dto.response;
+
+import static com.ftm.server.common.consts.PropertiesHolder.CDN_PATH;
+
+import com.ftm.server.domain.entity.PostProductImage;
+import lombok.Getter;
+
+@Getter
+public class PostProductImageResponse {
+
+    private final Long postProductImageId;
+    private final String imageUrl;
+
+    private PostProductImageResponse(PostProductImage postProductImage) {
+        this.postProductImageId = postProductImage.getId();
+        this.imageUrl = CDN_PATH + "/" + postProductImage.getObjectKey();
+    }
+
+    public static PostProductImageResponse from(PostProductImage postProductImage) {
+        return new PostProductImageResponse(postProductImage);
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/PostProductResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/PostProductResponse.java
@@ -1,0 +1,31 @@
+package com.ftm.server.adapter.in.web.post.dto.response;
+
+import com.ftm.server.application.vo.post.PostProductDetailVo;
+import com.ftm.server.domain.enums.HashTag;
+import java.util.Arrays;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PostProductResponse {
+
+    private final Long postProductId;
+    private final String name;
+    private final String brand;
+    private final List<String> hashTags;
+    private final PostProductImageResponse postProductImage;
+
+    private PostProductResponse(PostProductDetailVo postProductDetailVo) {
+        this.postProductId = postProductDetailVo.getPostProductId();
+        this.name = postProductDetailVo.getName();
+        this.brand = postProductDetailVo.getBrand();
+        this.hashTags =
+                Arrays.stream(postProductDetailVo.getHashTags()).map(HashTag::getValue).toList();
+        this.postProductImage =
+                PostProductImageResponse.from(postProductDetailVo.getPostProductImage());
+    }
+
+    public static PostProductResponse from(PostProductDetailVo postProductDetailVo) {
+        return new PostProductResponse(postProductDetailVo);
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/PostWriterResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/PostWriterResponse.java
@@ -1,0 +1,25 @@
+package com.ftm.server.adapter.in.web.post.dto.response;
+
+import static com.ftm.server.common.consts.PropertiesHolder.CDN_PATH;
+
+import com.ftm.server.domain.entity.User;
+import com.ftm.server.domain.entity.UserImage;
+import lombok.Getter;
+
+@Getter
+public class PostWriterResponse {
+
+    private final Long userId;
+    private final String nickname;
+    private final String imageUrl;
+
+    private PostWriterResponse(User user, UserImage userImage) {
+        this.userId = user.getId();
+        this.nickname = user.getNickname();
+        this.imageUrl = CDN_PATH + "/" + userImage.getObjectKey();
+    }
+
+    public static PostWriterResponse from(User user, UserImage userImage) {
+        return new PostWriterResponse(user, userImage);
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
@@ -1,40 +1,52 @@
 package com.ftm.server.adapter.out.persistence.adapter.post;
 
-import com.ftm.server.adapter.out.persistence.mapper.PostImageMapper;
-import com.ftm.server.adapter.out.persistence.mapper.PostMapper;
-import com.ftm.server.adapter.out.persistence.mapper.PostProductImageMapper;
-import com.ftm.server.adapter.out.persistence.mapper.PostProductMapper;
+import com.ftm.server.adapter.out.persistence.mapper.*;
 import com.ftm.server.adapter.out.persistence.model.*;
 import com.ftm.server.adapter.out.persistence.repository.*;
-import com.ftm.server.application.port.out.persistence.post.SavePostImagePort;
-import com.ftm.server.application.port.out.persistence.post.SavePostPort;
-import com.ftm.server.application.port.out.persistence.post.SavePostProductImagePort;
-import com.ftm.server.application.port.out.persistence.post.SavePostProductPort;
+import com.ftm.server.application.port.out.persistence.post.*;
+import com.ftm.server.application.query.FindByIdQuery;
+import com.ftm.server.application.query.FindByPostIdQuery;
+import com.ftm.server.application.query.FindByPostProductIdsQuery;
+import com.ftm.server.application.query.FindByUserIdQuery;
 import com.ftm.server.common.annotation.Adapter;
 import com.ftm.server.common.exception.CustomException;
 import com.ftm.server.common.response.enums.ErrorResponseCode;
-import com.ftm.server.domain.entity.Post;
-import com.ftm.server.domain.entity.PostImage;
-import com.ftm.server.domain.entity.PostProduct;
-import com.ftm.server.domain.entity.PostProductImage;
+import com.ftm.server.domain.entity.*;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @Adapter
 @RequiredArgsConstructor
 public class PostDomainPersistenceAdapter
-        implements SavePostPort, SavePostImagePort, SavePostProductPort, SavePostProductImagePort {
+        implements SavePostPort,
+                SavePostImagePort,
+                SavePostProductPort,
+                SavePostProductImagePort,
+                LoadPostPort,
+                LoadPostImagePort,
+                LoadPostProductPort,
+                LoadPostProductImagePort,
+                LoadUserForPostPort,
+                LoadUserImageForPostPort,
+                UpdatePostPort {
 
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
     private final PostProductRepository postProductRepository;
     private final PostProductImageRepository postProductImageRepository;
     private final UserRepository userRepository;
+    private final UserImageRepository userImageRepository;
 
     private final PostMapper postMapper;
     private final PostImageMapper postImageMapper;
     private final PostProductMapper postProductMapper;
     private final PostProductImageMapper postProductImageMapper;
+    private final UserMapper userMapper;
+    private final UserImageMapper userImageMapper;
 
     @Override
     public Post savePost(Post post) {
@@ -118,5 +130,72 @@ public class PostDomainPersistenceAdapter
         return postProductImageRepository.saveAll(postProductImageJpaEntities).stream()
                 .map(postProductImageMapper::toDomainEntity)
                 .toList();
+    }
+
+    @Override
+    public Optional<Post> loadPost(FindByIdQuery query) {
+        return postRepository.findById(query.getId()).map(postMapper::toDomainEntity);
+    }
+
+    @Override
+    public List<PostImage> loadPostImagesByPostId(FindByPostIdQuery query) {
+        PostJpaEntity postJpaEntity =
+                postRepository
+                        .findById(query.getPostId())
+                        .orElseThrow(() -> new CustomException(ErrorResponseCode.POST_NOT_FOUND));
+
+        return postImageRepository.findAllByPost(postJpaEntity).stream()
+                .map(postImageMapper::toDomainEntity)
+                .toList();
+    }
+
+    @Override
+    public List<PostProduct> loadPostProductsByPostId(FindByPostIdQuery query) {
+        PostJpaEntity postJpaEntity =
+                postRepository
+                        .findById(query.getPostId())
+                        .orElseThrow(() -> new CustomException(ErrorResponseCode.POST_NOT_FOUND));
+
+        return postProductRepository.findAllByPost(postJpaEntity).stream()
+                .map(postProductMapper::toDomainEntity)
+                .toList();
+    }
+
+    @Override
+    public Map<Long, PostProductImage> loadPostProductImagesByPostProductIds(
+            FindByPostProductIdsQuery query) {
+        List<PostProductImageJpaEntity> postProductImageJpaEntities =
+                postProductImageRepository.findByPostProductIds(query);
+
+        return postProductImageJpaEntities.stream()
+                .map(postProductImageMapper::toDomainEntity)
+                .collect(Collectors.toMap(PostProductImage::getPostProductId, Function.identity()));
+    }
+
+    @Override
+    public Optional<User> loadUserById(FindByIdQuery query) {
+        return userRepository.findById(query.getId()).map(userMapper::toDomainEntity);
+    }
+
+    @Override
+    public Optional<UserImage> loadUserImageByUserId(FindByUserIdQuery query) {
+        UserJpaEntity userJpaEntity =
+                userRepository
+                        .findById(query.getUserId())
+                        .orElseThrow(() -> CustomException.USER_NOT_FOUND);
+
+        return userImageRepository
+                .findByUserId(query.getUserId())
+                .map(userImageMapper::toDomainEntity);
+    }
+
+    @Override
+    public void updatePost(Post post) {
+        PostJpaEntity postJpaEntity =
+                postRepository
+                        .findById(post.getId())
+                        .orElseThrow(() -> new CustomException(ErrorResponseCode.POST_NOT_FOUND));
+
+        postJpaEntity.updatePostForDomainEntity(post);
     }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/model/PostJpaEntity.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/model/PostJpaEntity.java
@@ -91,4 +91,15 @@ public class PostJpaEntity extends BaseTimeJpaEntity {
                 .deletedAt(post.getDeletedAt())
                 .build();
     }
+
+    public void updatePostForDomainEntity(Post post) {
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.groomingCategory = post.getGroomingCategory();
+        this.hashtags = post.getHashtags();
+        this.viewCount = post.getViewCount();
+        this.likeCount = post.getLikeCount();
+        this.isDeleted = post.getIsDeleted();
+        this.deletedAt = post.getDeletedAt();
+    }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostImageRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostImageRepository.java
@@ -1,6 +1,11 @@
 package com.ftm.server.adapter.out.persistence.repository;
 
 import com.ftm.server.adapter.out.persistence.model.PostImageJpaEntity;
+import com.ftm.server.adapter.out.persistence.model.PostJpaEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostImageRepository extends JpaRepository<PostImageJpaEntity, Long> {}
+public interface PostImageRepository extends JpaRepository<PostImageJpaEntity, Long> {
+
+    List<PostImageJpaEntity> findAllByPost(PostJpaEntity post);
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostProductImageCustomRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostProductImageCustomRepository.java
@@ -1,0 +1,10 @@
+package com.ftm.server.adapter.out.persistence.repository;
+
+import com.ftm.server.adapter.out.persistence.model.PostProductImageJpaEntity;
+import com.ftm.server.application.query.FindByPostProductIdsQuery;
+import java.util.List;
+
+public interface PostProductImageCustomRepository {
+
+    List<PostProductImageJpaEntity> findByPostProductIds(FindByPostProductIdsQuery query);
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostProductImageCustomRepositoryImpl.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostProductImageCustomRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.ftm.server.adapter.out.persistence.repository;
+
+import static com.ftm.server.adapter.out.persistence.model.QPostProductImageJpaEntity.postProductImageJpaEntity;
+
+import com.ftm.server.adapter.out.persistence.model.PostProductImageJpaEntity;
+import com.ftm.server.application.query.FindByPostProductIdsQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PostProductImageCustomRepositoryImpl implements PostProductImageCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PostProductImageJpaEntity> findByPostProductIds(FindByPostProductIdsQuery query) {
+        return queryFactory
+                .selectFrom(postProductImageJpaEntity)
+                .where(postProductImageJpaEntity.postProduct.id.in(query.getPostProductIds()))
+                .fetch();
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostProductImageRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostProductImageRepository.java
@@ -4,4 +4,4 @@ import com.ftm.server.adapter.out.persistence.model.PostProductImageJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostProductImageRepository
-        extends JpaRepository<PostProductImageJpaEntity, Long> {}
+        extends JpaRepository<PostProductImageJpaEntity, Long>, PostProductImageCustomRepository {}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostProductRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostProductRepository.java
@@ -1,6 +1,11 @@
 package com.ftm.server.adapter.out.persistence.repository;
 
+import com.ftm.server.adapter.out.persistence.model.PostJpaEntity;
 import com.ftm.server.adapter.out.persistence.model.PostProductJpaEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostProductRepository extends JpaRepository<PostProductJpaEntity, Long> {}
+public interface PostProductRepository extends JpaRepository<PostProductJpaEntity, Long> {
+
+    List<PostProductJpaEntity> findAllByPost(PostJpaEntity post);
+}

--- a/src/main/java/com/ftm/server/application/port/in/post/LoadPostDetailUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/post/LoadPostDetailUseCase.java
@@ -1,0 +1,11 @@
+package com.ftm.server.application.port.in.post;
+
+import com.ftm.server.application.query.FindByIdQuery;
+import com.ftm.server.application.vo.post.PostDetailVo;
+import com.ftm.server.common.annotation.UseCase;
+
+@UseCase
+public interface LoadPostDetailUseCase {
+
+    PostDetailVo execute(FindByIdQuery query);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostImagePort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostImagePort.java
@@ -1,0 +1,12 @@
+package com.ftm.server.application.port.out.persistence.post;
+
+import com.ftm.server.application.query.FindByPostIdQuery;
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.PostImage;
+import java.util.List;
+
+@Port
+public interface LoadPostImagePort {
+
+    List<PostImage> loadPostImagesByPostId(FindByPostIdQuery query);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostPort.java
@@ -1,0 +1,12 @@
+package com.ftm.server.application.port.out.persistence.post;
+
+import com.ftm.server.application.query.FindByIdQuery;
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.Post;
+import java.util.Optional;
+
+@Port
+public interface LoadPostPort {
+
+    Optional<Post> loadPost(FindByIdQuery query);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostProductImagePort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostProductImagePort.java
@@ -1,0 +1,13 @@
+package com.ftm.server.application.port.out.persistence.post;
+
+import com.ftm.server.application.query.FindByPostProductIdsQuery;
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.PostProductImage;
+import java.util.Map;
+
+@Port
+public interface LoadPostProductImagePort {
+
+    Map<Long, PostProductImage> loadPostProductImagesByPostProductIds(
+            FindByPostProductIdsQuery query);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostProductPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostProductPort.java
@@ -1,0 +1,12 @@
+package com.ftm.server.application.port.out.persistence.post;
+
+import com.ftm.server.application.query.FindByPostIdQuery;
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.PostProduct;
+import java.util.List;
+
+@Port
+public interface LoadPostProductPort {
+
+    List<PostProduct> loadPostProductsByPostId(FindByPostIdQuery query);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadUserForPostPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadUserForPostPort.java
@@ -1,0 +1,12 @@
+package com.ftm.server.application.port.out.persistence.post;
+
+import com.ftm.server.application.query.FindByIdQuery;
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.User;
+import java.util.Optional;
+
+@Port
+public interface LoadUserForPostPort {
+
+    Optional<User> loadUserById(FindByIdQuery query);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadUserImageForPostPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadUserImageForPostPort.java
@@ -1,0 +1,12 @@
+package com.ftm.server.application.port.out.persistence.post;
+
+import com.ftm.server.application.query.FindByUserIdQuery;
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.UserImage;
+import java.util.Optional;
+
+@Port
+public interface LoadUserImageForPostPort {
+
+    Optional<UserImage> loadUserImageByUserId(FindByUserIdQuery query);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/UpdatePostPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/UpdatePostPort.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.out.persistence.post;
+
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.Post;
+
+@Port
+public interface UpdatePostPort {
+
+    void updatePost(Post post);
+}

--- a/src/main/java/com/ftm/server/application/query/FindByPostIdQuery.java
+++ b/src/main/java/com/ftm/server/application/query/FindByPostIdQuery.java
@@ -1,0 +1,17 @@
+package com.ftm.server.application.query;
+
+import lombok.Getter;
+
+@Getter
+public class FindByPostIdQuery {
+
+    private final Long postId;
+
+    private FindByPostIdQuery(Long postId) {
+        this.postId = postId;
+    }
+
+    public static FindByPostIdQuery of(Long postId) {
+        return new FindByPostIdQuery(postId);
+    }
+}

--- a/src/main/java/com/ftm/server/application/query/FindByPostProductIdsQuery.java
+++ b/src/main/java/com/ftm/server/application/query/FindByPostProductIdsQuery.java
@@ -1,0 +1,18 @@
+package com.ftm.server.application.query;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class FindByPostProductIdsQuery {
+
+    private final List<Long> postProductIds;
+
+    private FindByPostProductIdsQuery(List<Long> postProductIds) {
+        this.postProductIds = postProductIds;
+    }
+
+    public static FindByPostProductIdsQuery of(List<Long> postProductIds) {
+        return new FindByPostProductIdsQuery(postProductIds);
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/post/LoadPostDetailService.java
+++ b/src/main/java/com/ftm/server/application/service/post/LoadPostDetailService.java
@@ -1,0 +1,79 @@
+package com.ftm.server.application.service.post;
+
+import com.ftm.server.application.port.in.post.LoadPostDetailUseCase;
+import com.ftm.server.application.port.out.persistence.post.*;
+import com.ftm.server.application.query.FindByIdQuery;
+import com.ftm.server.application.query.FindByPostIdQuery;
+import com.ftm.server.application.query.FindByPostProductIdsQuery;
+import com.ftm.server.application.query.FindByUserIdQuery;
+import com.ftm.server.application.vo.post.PostDetailVo;
+import com.ftm.server.common.exception.CustomException;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.entity.*;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoadPostDetailService implements LoadPostDetailUseCase {
+
+    private final LoadPostPort loadPostPort;
+    private final LoadPostImagePort loadPostImagePort;
+    private final LoadPostProductPort loadPostProductPort;
+    private final LoadPostProductImagePort loadPostProductImagePort;
+    private final LoadUserForPostPort loadUserForPostPort;
+    private final LoadUserImageForPostPort loadUserImageForPostPort;
+    private final UpdatePostPort updatePostPort;
+
+    @Override
+    @Transactional
+    public PostDetailVo execute(FindByIdQuery query) {
+        // 게시글 조회
+        Post post =
+                loadPostPort
+                        .loadPost(query)
+                        .orElseThrow(() -> new CustomException(ErrorResponseCode.POST_NOT_FOUND));
+        if (post.getIsDeleted()) { // 게시글이 삭제된 경우 예외처리
+            throw new CustomException(ErrorResponseCode.POST_NOT_FOUND);
+        }
+
+        // 조회수 업데이트
+        post.updateViewCount(post.getViewCount() + 1);
+        updatePostPort.updatePost(post);
+
+        // 유저 조회
+        User user =
+                loadUserForPostPort
+                        .loadUserById(FindByIdQuery.of(post.getUserId()))
+                        .orElseThrow(() -> CustomException.USER_NOT_FOUND);
+
+        // 유저 이미지 조회
+        UserImage userImage =
+                loadUserImageForPostPort
+                        .loadUserImageByUserId(FindByUserIdQuery.of(user.getId()))
+                        .orElseThrow(
+                                () -> new CustomException(ErrorResponseCode.USER_IMAGE_NOT_FOUND));
+
+        // 게시글 이미지 목록 조회
+        List<PostImage> postImages =
+                loadPostImagePort.loadPostImagesByPostId(FindByPostIdQuery.of(post.getId()));
+
+        // 게시글 상품 목록 조회
+        List<PostProduct> postProducts =
+                loadPostProductPort.loadPostProductsByPostId(FindByPostIdQuery.of(post.getId()));
+
+        // 게시글 상품 별 이미지 Map, 여러 상품의 이미지 정보 한번에 조회
+        Map<Long, PostProductImage> postProductImageMap =
+                loadPostProductImagePort.loadPostProductImagesByPostProductIds(
+                        FindByPostProductIdsQuery.of(
+                                postProducts.stream().map(PostProduct::getId).toList()));
+
+        return PostDetailVo.from(
+                post, user, userImage, postImages, postProducts, postProductImageMap);
+    }
+}

--- a/src/main/java/com/ftm/server/application/vo/post/PostDetailVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/PostDetailVo.java
@@ -1,0 +1,63 @@
+package com.ftm.server.application.vo.post;
+
+import com.ftm.server.domain.entity.*;
+import com.ftm.server.domain.enums.GroomingCategory;
+import com.ftm.server.domain.enums.HashTag;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class PostDetailVo {
+
+    private final Long postId;
+    private final String title;
+    private final String content;
+    private final GroomingCategory groomingCategory;
+    private final HashTag[] hashTags;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final User user;
+    private final UserImage userImage;
+    private final List<PostImage> postImages;
+    private final List<PostProductDetailVo> products;
+
+    private PostDetailVo(
+            Post post,
+            User user,
+            UserImage userImage,
+            List<PostImage> postImages,
+            List<PostProductDetailVo> products) {
+        this.postId = post.getId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.groomingCategory = post.getGroomingCategory();
+        this.hashTags = post.getHashtags();
+        this.viewCount = post.getViewCount();
+        this.likeCount = post.getLikeCount();
+        this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getUpdatedAt();
+        this.user = user;
+        this.userImage = userImage;
+        this.postImages = postImages;
+        this.products = products;
+    }
+
+    public static PostDetailVo from(
+            Post post,
+            User user,
+            UserImage userImage,
+            List<PostImage> postImages,
+            List<PostProduct> postProducts,
+            Map<Long, PostProductImage> postProductImageMap) {
+        return new PostDetailVo(
+                post,
+                user,
+                userImage,
+                postImages,
+                PostProductDetailVo.listFrom(postProducts, postProductImageMap));
+    }
+}

--- a/src/main/java/com/ftm/server/application/vo/post/PostProductDetailVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/PostProductDetailVo.java
@@ -1,0 +1,43 @@
+package com.ftm.server.application.vo.post;
+
+import com.ftm.server.domain.entity.PostProduct;
+import com.ftm.server.domain.entity.PostProductImage;
+import com.ftm.server.domain.enums.HashTag;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class PostProductDetailVo {
+
+    private final Long postProductId;
+    private final String name;
+    private final String brand;
+    private final HashTag[] hashTags;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final PostProductImage postProductImage;
+
+    private PostProductDetailVo(PostProduct postProduct, PostProductImage postProductImage) {
+        this.postProductId = postProduct.getId();
+        this.name = postProduct.getName();
+        this.brand = postProduct.getBrand();
+        this.hashTags = postProduct.getHashTags();
+        this.createdAt = postProduct.getCreatedAt();
+        this.updatedAt = postProduct.getUpdatedAt();
+        this.postProductImage = postProductImage;
+    }
+
+    public static List<PostProductDetailVo> listFrom(
+            List<PostProduct> postProducts, Map<Long, PostProductImage> postProductImageMap) {
+        return postProducts.stream()
+                .map(postProduct -> from(postProduct, postProductImageMap.get(postProduct.getId())))
+                .toList();
+    }
+
+    public static PostProductDetailVo from(
+            PostProduct postProduct, PostProductImage postProductImage) {
+        return new PostProductDetailVo(postProduct, postProductImage);
+    }
+}

--- a/src/main/java/com/ftm/server/common/response/enums/ErrorResponseCode.java
+++ b/src/main/java/com/ftm/server/common/response/enums/ErrorResponseCode.java
@@ -38,6 +38,7 @@ public enum ErrorResponseCode {
     GROOMING_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404_004", "요청한 그루밍 카테고리 정보를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "E404_005", "요청한 게시글을 찾을 수 없습니다."),
     POST_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "E404_006", "요청한 상품을 찾을 수 없습니다."),
+    POST_PRODUCT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404_007", "요청한 상품 이미지를 찾을 수 없습니다."),
 
     // 409번
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "E409_001", "이미 존재하는 사용자입니다."),

--- a/src/main/java/com/ftm/server/domain/entity/Post.java
+++ b/src/main/java/com/ftm/server/domain/entity/Post.java
@@ -93,4 +93,8 @@ public class Post extends BaseTime {
                 .isDeleted(false)
                 .build();
     }
+
+    public void updateViewCount(int viewCount) {
+        this.viewCount = viewCount;
+    }
 }

--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
         "/api/users/email/duplication",
         "/api/users/options",
         "/api/grooming/tests",
-        "/api/auth/session/validity"
+        "/api/auth/session/validity",
+        "/api/posts/*"
     };
 
     private static final String[] POST_ANONYMOUS_MATCHERS = {

--- a/src/test/java/com/ftm/server/post/LoadPostDetailTest.java
+++ b/src/test/java/com/ftm/server/post/LoadPostDetailTest.java
@@ -1,0 +1,183 @@
+package com.ftm.server.post;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.in.web.post.dto.request.SavePostProductRequest;
+import com.ftm.server.adapter.in.web.post.dto.request.SavePostRequest;
+import com.ftm.server.application.command.post.SavePostCommand;
+import com.ftm.server.application.port.in.post.SavePostUseCase;
+import com.ftm.server.application.port.out.s3.S3ImageDeletePort;
+import com.ftm.server.application.port.out.s3.S3PostImageUploadPort;
+import com.ftm.server.application.port.out.s3.S3PostProductImageUploadPort;
+import com.ftm.server.application.port.out.transcation.AfterRollbackExecutorPort;
+import com.ftm.server.application.vo.post.PostInfoVo;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.entity.User;
+import com.ftm.server.domain.enums.GroomingCategory;
+import com.ftm.server.domain.enums.HashTag;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.request.ParameterDescriptor;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class LoadPostDetailTest extends BaseTest {
+
+    @Autowired private SavePostUseCase savePostUseCase;
+    @MockitoSpyBean private S3PostImageUploadPort s3PostImageUploadPort;
+    @MockitoSpyBean private S3PostProductImageUploadPort s3PostProductImageUploadPort;
+    @MockitoSpyBean private S3ImageDeletePort s3ImageDeletePort;
+    @MockitoSpyBean private AfterRollbackExecutorPort afterRollbackExecutorPort;
+
+    private final ParameterDescriptor pathParametersForPostId =
+            parameterWithName("postId").description("게시글 ID");
+
+    private final List<FieldDescriptor> responseFieldLoadPostDetail =
+            List.of(
+                    fieldWithPath("status").type(NUMBER).description("응답 상태"),
+                    fieldWithPath("code").type(STRING).description("상태 코드"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data").type(OBJECT).optional().description("응답 데이터"),
+                    fieldWithPath("data.postId").type(NUMBER).description("게시글 ID"),
+                    fieldWithPath("data.title").type(STRING).description("게시글 제목"),
+                    fieldWithPath("data.content").type(STRING).description("게시글 내용"),
+                    fieldWithPath("data.groomingCategory").type(STRING).description("게시글 그루밍 카테고리"),
+                    fieldWithPath("data.hashTags[]").type(ARRAY).description("게시글 해시태그 목록"),
+                    fieldWithPath("data.viewCount").type(NUMBER).description("게시글 조회수"),
+                    fieldWithPath("data.likeCount").type(NUMBER).description("게시글 좋아요 수"),
+                    fieldWithPath("data.createdAt").type(STRING).description("게시글 생성 날짜"),
+                    fieldWithPath("data.updatedAt").type(STRING).description("게시글 수정 날짜"),
+                    fieldWithPath("data.postImages[]").type(ARRAY).description("게시글 이미지 목록 정보"),
+                    fieldWithPath("data.postImages[].postImageId")
+                            .type(NUMBER)
+                            .description("게시글 이미지 ID"),
+                    fieldWithPath("data.postImages[].imageUrl")
+                            .type(STRING)
+                            .description("게시글 이미지 URL"),
+                    fieldWithPath("data.writer").type(OBJECT).description("게시글 작성자 정보"),
+                    fieldWithPath("data.writer.userId").type(NUMBER).description("게시글 작성자 ID"),
+                    fieldWithPath("data.writer.nickname").type(STRING).description("게시글 작성자 닉네임"),
+                    fieldWithPath("data.writer.imageUrl")
+                            .type(STRING)
+                            .description("게시글 작성자 프로필 이미지 URL"),
+                    fieldWithPath("data.postProducts[]").type(ARRAY).description("게시글 상품 목록 정보"),
+                    fieldWithPath("data.postProducts[].postProductId")
+                            .type(NUMBER)
+                            .description("게시글 상품 ID"),
+                    fieldWithPath("data.postProducts[].name").type(STRING).description("게시글 상품 이름"),
+                    fieldWithPath("data.postProducts[].brand")
+                            .type(STRING)
+                            .description("게시글 상품 브랜드"),
+                    fieldWithPath("data.postProducts[].hashTags[]")
+                            .type(ARRAY)
+                            .description("게시글 상품 해시태그 목록"),
+                    fieldWithPath("data.postProducts[].postProductImage")
+                            .type(OBJECT)
+                            .description("게시글 상품 이미지 정보"),
+                    fieldWithPath("data.postProducts[].postProductImage.postProductImageId")
+                            .type(NUMBER)
+                            .description("게시글 상품 이미지 ID"),
+                    fieldWithPath("data.postProducts[].postProductImage.imageUrl")
+                            .type(STRING)
+                            .description("게시글 상품 이미지 URL"));
+
+    private Long savedPostId;
+
+    private ResultActions getResultActions(Long postId) throws Exception {
+        return mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/api/posts/{postId}", postId)
+                        .accept(MediaType.APPLICATION_JSON));
+    }
+
+    private RestDocumentationResultHandler getDocument(Integer identifier) {
+        return document(
+                "loadPostDetail/" + identifier,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint(), getModifiedHeader()),
+                pathParameters(pathParametersForPostId),
+                responseFields(responseFieldLoadPostDetail),
+                resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("유저픽 게시글")
+                                .summary("유저픽 게시글 상세 조회 api")
+                                .description("유저픽 게시글 상세 조회 api 입니다.")
+                                .responseFields(responseFieldLoadPostDetail)
+                                .build()));
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        User user = createTestUser("test@gmail.com", "test1234!");
+
+        SavePostRequest postRequest =
+                new SavePostRequest(
+                        "독도 토너 추천",
+                        GroomingCategory.BEAUTY,
+                        List.of(HashTag.PERFUME),
+                        "<div>test</div>",
+                        List.of(new SavePostProductRequest(-1, "독도 토너", "라운드랩", List.of())));
+
+        // s3 실제 호출 대신 mock 대입
+        doReturn(List.of()).when(s3PostImageUploadPort).uploadImages(new ArrayList<>(List.of()));
+        doReturn(List.of())
+                .when(s3PostProductImageUploadPort)
+                .uploadImages(new ArrayList<>(List.of()));
+        doNothing().when(s3ImageDeletePort).deleteImages(any());
+        doNothing().when(afterRollbackExecutorPort).doAfterRollback(any());
+
+        PostInfoVo post =
+                savePostUseCase.execute(
+                        SavePostCommand.from(user.getId(), postRequest, List.of(), List.of()));
+        savedPostId = post.getId();
+    }
+
+    @Test
+    @Transactional
+    void 유저픽_게시글_상세_조회_성공() throws Exception {
+        // when
+        ResultActions resultActions = getResultActions(savedPostId);
+
+        // then
+        resultActions.andExpect(status().isOk()).andDo(print());
+
+        // document
+        resultActions.andDo(getDocument(1));
+    }
+
+    @Test
+    @Transactional
+    void 유저픽_게시글_상세_조회_실패() throws Exception {
+        // when
+        ResultActions resultActions = getResultActions(1000L);
+
+        // then
+        resultActions
+                .andExpect(status().is(ErrorResponseCode.POST_NOT_FOUND.getHttpStatus().value()))
+                .andDo(print());
+
+        // document
+        resultActions.andDo(getDocument(2));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #99 

## 📌 작업 내용 및 특이사항

- 유저픽 게시글 상세 조회 기능 구현했습니다
- 유저픽 게시글, 게시글 이미지, 게시글 상품, 게시글 상품 이미지 정보를 모두 응답하도록 설계했습니다
- 이 API 요청 시 게시글의 view_count(조회수) 필드가 +1 씩 업데이트 되도록 구현했습니다

## 🔍 참고사항

-

## 📚 기타

-