### PR TITLE
feat : 회원 탈퇴 api 추가(#107)

### DIFF
--- a/src/docs/asciidoc/user-api.adoc
+++ b/src/docs/asciidoc/user-api.adoc
@@ -162,3 +162,17 @@ include::{snippetsDir}/userInfoUpdate/1/response-fields.adoc[]
 include::{snippetsDir}/userInfoUpdate/2/http-response.adoc[]
 실패 2
 include::{snippetsDir}/userInfoUpdate/3/http-response.adoc[]
+
+
+=== **9. 회원 탈퇴 api**
+
+회원 탈퇴를 진행
+
+==== Request
+include::{snippetsDir}/userExit/1/http-request.adoc[]
+
+==== 성공 Response
+include::{snippetsDir}/userExit/1/http-response.adoc[]
+
+==== Response Body Fields
+include::{snippetsDir}/userExit/1/response-fields.adoc[]

--- a/src/main/java/com/ftm/server/adapter/in/web/user/controller/UserExitController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/user/controller/UserExitController.java
@@ -1,0 +1,34 @@
+package com.ftm.server.adapter.in.web.user.controller;
+
+import com.ftm.server.application.command.user.DeleteUserByIdCommand;
+import com.ftm.server.application.port.in.user.UserExitUseCase;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import com.ftm.server.infrastructure.security.UserPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserExitController {
+
+    private final UserExitUseCase userExitUseCase;
+
+    @DeleteMapping("api/users")
+    public ResponseEntity<ApiResponse> userExit(
+            @AuthenticationPrincipal UserPrincipal user, HttpServletRequest request) {
+        // 회원 탈퇴
+        userExitUseCase.execute(DeleteUserByIdCommand.of(user.getId()));
+        // 로그아웃 처리
+        request.getSession().invalidate();
+        SecurityContextHolder.clearContext();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessResponseCode.OK));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/user/UserDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/user/UserDomainPersistenceAdapter.java
@@ -1,24 +1,20 @@
 package com.ftm.server.adapter.out.persistence.adapter.user;
 
 import com.ftm.server.adapter.out.persistence.mapper.EmailVerificationLogsMapper;
+import com.ftm.server.adapter.out.persistence.mapper.PostMapper;
 import com.ftm.server.adapter.out.persistence.mapper.UserImageMapper;
 import com.ftm.server.adapter.out.persistence.mapper.UserMapper;
-import com.ftm.server.adapter.out.persistence.model.EmailVerificationLogsJpaEntity;
-import com.ftm.server.adapter.out.persistence.model.GroomingLevelJpaEntity;
-import com.ftm.server.adapter.out.persistence.model.UserImageJpaEntity;
-import com.ftm.server.adapter.out.persistence.model.UserJpaEntity;
-import com.ftm.server.adapter.out.persistence.repository.EmailVerificationLogsRepository;
-import com.ftm.server.adapter.out.persistence.repository.GroomingLevelRepository;
-import com.ftm.server.adapter.out.persistence.repository.UserImageRepository;
-import com.ftm.server.adapter.out.persistence.repository.UserRepository;
-import com.ftm.server.application.command.user.EmailVerificationLogCreationCommand;
+import com.ftm.server.adapter.out.persistence.model.*;
+import com.ftm.server.adapter.out.persistence.repository.*;
+import com.ftm.server.application.command.user.*;
 import com.ftm.server.application.port.out.persistence.user.*;
 import com.ftm.server.application.query.*;
 import com.ftm.server.common.annotation.Adapter;
 import com.ftm.server.common.exception.CustomException;
-import com.ftm.server.domain.entity.EmailVerificationLogs;
-import com.ftm.server.domain.entity.User;
-import com.ftm.server.domain.entity.UserImage;
+import com.ftm.server.domain.entity.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,19 +31,29 @@ public class UserDomainPersistenceAdapter
                 SaveUserImagePort,
                 LoadUserPort,
                 LoadUserImagePort,
-                UpdateUserInfoPort,
-                UpdateUserImagePort {
+                UpdateUserPort,
+                UpdateUserImagePort,
+                LoadPostUserDomainPort,
+                UpdatePostUserDomainPort,
+                DeleteUserImagePort,
+                DeleteGroomingTestResultPort,
+                DeleteUserPort,
+                DeleteBookmarkPort {
 
     // repository
     private final EmailVerificationLogsRepository emailVerificationLogsRepository;
     private final UserRepository userRepository;
     private final GroomingLevelRepository groomingLevelRepository;
     private final UserImageRepository userImageRepository;
+    private final PostRepository postRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final GroomingTestResultRepository groomingTestResultRepository;
 
     // mapper
     private final EmailVerificationLogsMapper emailVerificationLogsMapper;
     private final UserMapper userMapper;
     private final UserImageMapper userImageMapper;
+    private final PostMapper postMapper;
 
     @Override
     public Optional<EmailVerificationLogs> loadEmailVerificationLogByEmail(FindByEmailQuery query) {
@@ -115,9 +121,25 @@ public class UserDomainPersistenceAdapter
     public User loadUserById(FindByUserIdQuery query) {
         UserJpaEntity userJpaEntity =
                 userRepository
-                        .findById(query.getUserId())
+                        .findByIdAndIsDeleted(query.getUserId(), false)
                         .orElseThrow(() -> CustomException.USER_NOT_FOUND);
         return userMapper.toDomainEntity(userJpaEntity);
+    }
+
+    @Override
+    public User loadUserByRole(FindUserByRoleQuery query) {
+        UserJpaEntity userJpaEntity = userRepository.findByRole(query.getUserRole()).get();
+        return userMapper.toDomainEntity(userJpaEntity);
+    }
+
+    @Override
+    public List<User> loadUserByDeleteOption(FindUserByDeleteOptionQuery query) {
+        return userRepository
+                .findAllByDeletedBefore(
+                        query.getIsDeleted(), query.getDeletedAt().atTime(23, 59, 59))
+                .stream()
+                .map(userMapper::toDomainEntity)
+                .toList();
     }
 
     @Override
@@ -131,7 +153,7 @@ public class UserDomainPersistenceAdapter
     }
 
     @Override
-    public void updateUserInfo(User user) {
+    public void updateUser(User user) {
         UserJpaEntity savedUser =
                 userRepository
                         .findById(user.getId())
@@ -155,5 +177,50 @@ public class UserDomainPersistenceAdapter
         }
 
         userImageJpaEntity.updateFromDomainEntity(userImage);
+    }
+
+    @Override
+    public List<Post> loadPostListByUser(FindByUserIdQuery query) {
+        return postRepository.findByUserId(query.getUserId()).stream()
+                .map(postMapper::toDomainEntity)
+                .toList();
+    }
+
+    @Override
+    public void updatePostListBySystemUser(List<Post> postList) {
+        UserJpaEntity systemUser = userRepository.findById(postList.get(0).getUserId()).get();
+
+        Map<Long, Post> map = new HashMap<>();
+        postList.forEach(p -> map.put(p.getId(), p));
+
+        List<PostJpaEntity> postJpaEntityList =
+                postRepository.findAllById(postList.stream().map(Post::getId).toList());
+
+        postJpaEntityList.forEach(
+                pj -> pj.updatePostForDomainEntity(map.get(pj.getId()), systemUser));
+    }
+
+    @Override
+    public void deleteGroomingTestResultByUserList(
+            DeleteGroomingTestResultByUserIdCommand command) {
+        groomingTestResultRepository.deleteAllByUserIdList(command.getUserIdList());
+    }
+
+    @Override
+    public List<String> deleteUserImageByUserList(DeleteUserImageByUserIdCommand command) {
+        List<String> imageKeyList =
+                userImageRepository.findAllByUserIdList(command.getUserIdList());
+        userImageRepository.deleteAllByUserIdList(command.getUserIdList());
+        return imageKeyList;
+    }
+
+    @Override
+    public void deleteAllUserByIdList(DeleteAllUserByIdListCommand command) {
+        userRepository.deleteAllByUserIdList(command.getUserIdList());
+    }
+
+    @Override
+    public void deleteBookmarkByUserList(DeleteBookmarkByUserIdCommand command) {
+        bookmarkRepository.deleteAllByUserIdList(command.getUserIdList());
     }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/model/PostJpaEntity.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/model/PostJpaEntity.java
@@ -102,4 +102,16 @@ public class PostJpaEntity extends BaseTimeJpaEntity {
         this.isDeleted = post.getIsDeleted();
         this.deletedAt = post.getDeletedAt();
     }
+
+    public void updatePostForDomainEntity(Post post, UserJpaEntity user) {
+        this.title = post.getTitle();
+        this.user = user;
+        this.content = post.getContent();
+        this.groomingCategory = post.getGroomingCategory();
+        this.hashtags = post.getHashtags();
+        this.viewCount = post.getViewCount();
+        this.likeCount = post.getLikeCount();
+        this.isDeleted = post.getIsDeleted();
+        this.deletedAt = post.getDeletedAt();
+    }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/BookmarkRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/BookmarkRepository.java
@@ -1,6 +1,14 @@
 package com.ftm.server.adapter.out.persistence.repository;
 
 import com.ftm.server.adapter.out.persistence.model.BookmarkJpaEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface BookmarkRepository extends JpaRepository<BookmarkJpaEntity, Long> {}
+public interface BookmarkRepository extends JpaRepository<BookmarkJpaEntity, Long> {
+    @Modifying
+    @Query("DELETE FROM BookmarkJpaEntity b WHERE b.user.id in (:userIds)")
+    void deleteAllByUserIdList(@Param("userIds") List<Long> userIds);
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/GroomingTestResultRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/GroomingTestResultRepository.java
@@ -1,8 +1,16 @@
 package com.ftm.server.adapter.out.persistence.repository;
 
 import com.ftm.server.adapter.out.persistence.model.GroomingTestResultJpaEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GroomingTestResultRepository
         extends JpaRepository<GroomingTestResultJpaEntity, Long>,
-                GroomingTestResultCustomRepository {}
+                GroomingTestResultCustomRepository {
+    @Modifying
+    @Query("DELETE FROM GroomingTestResultJpaEntity g WHERE g.user.id in (:userIds)")
+    void deleteAllByUserIdList(@Param("userIds") List<Long> userIds);
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostRepository.java
@@ -1,6 +1,10 @@
 package com.ftm.server.adapter.out.persistence.repository;
 
 import com.ftm.server.adapter.out.persistence.model.PostJpaEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<PostJpaEntity, Long> {}
+public interface PostRepository extends JpaRepository<PostJpaEntity, Long> {
+
+    List<PostJpaEntity> findByUserId(Long userId);
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/UserImageRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/UserImageRepository.java
@@ -1,10 +1,21 @@
 package com.ftm.server.adapter.out.persistence.repository;
 
 import com.ftm.server.adapter.out.persistence.model.UserImageJpaEntity;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserImageRepository extends JpaRepository<UserImageJpaEntity, Long> {
 
     Optional<UserImageJpaEntity> findByUserId(Long userId);
+
+    @Modifying
+    @Query("DELETE FROM UserImageJpaEntity u WHERE u.user.id in (:userIds)")
+    void deleteAllByUserIdList(@Param("userIds") List<Long> userIds);
+
+    @Query("SELECT ui.objectKey FROM UserImageJpaEntity ui WHERE ui.user.id in (:userIds)")
+    List<String> findAllByUserIdList(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/UserRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/UserRepository.java
@@ -2,10 +2,18 @@ package com.ftm.server.adapter.out.persistence.repository;
 
 import com.ftm.server.adapter.out.persistence.model.UserJpaEntity;
 import com.ftm.server.domain.enums.SocialProvider;
+import com.ftm.server.domain.enums.UserRole;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<UserJpaEntity, Long> {
+
+    Optional<UserJpaEntity> findByIdAndIsDeleted(Long userId, Boolean isDeleted);
 
     Boolean existsByEmail(String email);
 
@@ -15,4 +23,14 @@ public interface UserRepository extends JpaRepository<UserJpaEntity, Long> {
             SocialProvider socialProvider, String socialId);
 
     Boolean existsBySocialIdAndSocialProvider(String socialId, SocialProvider socialProvider);
+
+    Optional<UserJpaEntity> findByRole(UserRole role);
+
+    @Modifying
+    @Query("DELETE FROM UserJpaEntity u WHERE u.id in (:userIds)")
+    void deleteAllByUserIdList(@Param("userIds") List<Long> userIds);
+
+    @Query("SELECT u FROM UserJpaEntity u WHERE u.isDeleted = :isDeleted And u.deletedAt <=:end")
+    List<UserJpaEntity> findAllByDeletedBefore(
+            @Param("isDeleted") Boolean isDeleted, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/ftm/server/adapter/out/scheduler/UserHardDeleteScheduler.java
+++ b/src/main/java/com/ftm/server/adapter/out/scheduler/UserHardDeleteScheduler.java
@@ -1,0 +1,19 @@
+package com.ftm.server.adapter.out.scheduler;
+
+import com.ftm.server.application.port.in.user.UserHardDeleteUseCase;
+import com.ftm.server.common.annotation.Adapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Adapter
+@RequiredArgsConstructor
+public class UserHardDeleteScheduler {
+
+    private final UserHardDeleteUseCase userHardDeleteUseCase;
+
+    // 매일 새벽 3시 hard delete 진행
+    @Scheduled(cron = "0 0 3 * * *")
+    public void run() {
+        userHardDeleteUseCase.execute();
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/user/DeleteAllUserByIdListCommand.java
+++ b/src/main/java/com/ftm/server/application/command/user/DeleteAllUserByIdListCommand.java
@@ -1,0 +1,13 @@
+package com.ftm.server.application.command.user;
+
+import java.util.*;
+import lombok.Data;
+
+@Data
+public class DeleteAllUserByIdListCommand {
+    private final List<Long> userIdList;
+
+    public static DeleteAllUserByIdListCommand of(List<Long> userIdList) {
+        return new DeleteAllUserByIdListCommand(userIdList);
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/user/DeleteBookmarkByUserIdCommand.java
+++ b/src/main/java/com/ftm/server/application/command/user/DeleteBookmarkByUserIdCommand.java
@@ -1,0 +1,13 @@
+package com.ftm.server.application.command.user;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class DeleteBookmarkByUserIdCommand {
+    private final List<Long> userIdList;
+
+    public static DeleteBookmarkByUserIdCommand of(List<Long> userIdList) {
+        return new DeleteBookmarkByUserIdCommand(userIdList);
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/user/DeleteGroomingTestResultByUserIdCommand.java
+++ b/src/main/java/com/ftm/server/application/command/user/DeleteGroomingTestResultByUserIdCommand.java
@@ -1,0 +1,13 @@
+package com.ftm.server.application.command.user;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class DeleteGroomingTestResultByUserIdCommand {
+    private final List<Long> userIdList;
+
+    public static DeleteGroomingTestResultByUserIdCommand of(List<Long> userIdList) {
+        return new DeleteGroomingTestResultByUserIdCommand(userIdList);
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/user/DeleteUserByIdCommand.java
+++ b/src/main/java/com/ftm/server/application/command/user/DeleteUserByIdCommand.java
@@ -1,0 +1,12 @@
+package com.ftm.server.application.command.user;
+
+import lombok.Data;
+
+@Data
+public class DeleteUserByIdCommand {
+    private final Long userId;
+
+    public static DeleteUserByIdCommand of(Long userId) {
+        return new DeleteUserByIdCommand(userId);
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/user/DeleteUserImageByUserIdCommand.java
+++ b/src/main/java/com/ftm/server/application/command/user/DeleteUserImageByUserIdCommand.java
@@ -1,0 +1,13 @@
+package com.ftm.server.application.command.user;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class DeleteUserImageByUserIdCommand {
+    private final List<Long> userIdList;
+
+    public static DeleteUserImageByUserIdCommand of(List<Long> userIdList) {
+        return new DeleteUserImageByUserIdCommand(userIdList);
+    }
+}

--- a/src/main/java/com/ftm/server/application/port/in/user/UserExitUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/user/UserExitUseCase.java
@@ -1,0 +1,9 @@
+package com.ftm.server.application.port.in.user;
+
+import com.ftm.server.application.command.user.DeleteUserByIdCommand;
+import com.ftm.server.common.annotation.Port;
+
+@Port
+public interface UserExitUseCase {
+    void execute(DeleteUserByIdCommand query);
+}

--- a/src/main/java/com/ftm/server/application/port/in/user/UserHardDeleteUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/user/UserHardDeleteUseCase.java
@@ -1,0 +1,5 @@
+package com.ftm.server.application.port.in.user;
+
+public interface UserHardDeleteUseCase {
+    void execute();
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/user/DeleteBookmarkPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/user/DeleteBookmarkPort.java
@@ -1,0 +1,9 @@
+package com.ftm.server.application.port.out.persistence.user;
+
+import com.ftm.server.application.command.user.DeleteBookmarkByUserIdCommand;
+import com.ftm.server.common.annotation.Port;
+
+@Port
+public interface DeleteBookmarkPort {
+    void deleteBookmarkByUserList(DeleteBookmarkByUserIdCommand command);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/user/DeleteGroomingTestResultPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/user/DeleteGroomingTestResultPort.java
@@ -1,0 +1,9 @@
+package com.ftm.server.application.port.out.persistence.user;
+
+import com.ftm.server.application.command.user.DeleteGroomingTestResultByUserIdCommand;
+import com.ftm.server.common.annotation.Port;
+
+@Port
+public interface DeleteGroomingTestResultPort {
+    void deleteGroomingTestResultByUserList(DeleteGroomingTestResultByUserIdCommand command);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/user/DeleteUserImagePort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/user/DeleteUserImagePort.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.out.persistence.user;
+
+import com.ftm.server.application.command.user.DeleteUserImageByUserIdCommand;
+import com.ftm.server.common.annotation.Port;
+import java.util.List;
+
+@Port
+public interface DeleteUserImagePort {
+    List<String> deleteUserImageByUserList(DeleteUserImageByUserIdCommand command);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/user/DeleteUserPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/user/DeleteUserPort.java
@@ -1,0 +1,9 @@
+package com.ftm.server.application.port.out.persistence.user;
+
+import com.ftm.server.application.command.user.DeleteAllUserByIdListCommand;
+import com.ftm.server.common.annotation.Port;
+
+@Port
+public interface DeleteUserPort {
+    void deleteAllUserByIdList(DeleteAllUserByIdListCommand command);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/user/LoadPostUserDomainPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/user/LoadPostUserDomainPort.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.out.persistence.user;
+
+import com.ftm.server.application.query.FindByUserIdQuery;
+import com.ftm.server.domain.entity.Post;
+import java.util.List;
+
+public interface LoadPostUserDomainPort {
+
+    List<Post> loadPostListByUser(FindByUserIdQuery query);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/user/LoadUserPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/user/LoadUserPort.java
@@ -1,8 +1,17 @@
 package com.ftm.server.application.port.out.persistence.user;
 
 import com.ftm.server.application.query.FindByUserIdQuery;
+import com.ftm.server.application.query.FindUserByDeleteOptionQuery;
+import com.ftm.server.application.query.FindUserByRoleQuery;
+import com.ftm.server.common.annotation.Port;
 import com.ftm.server.domain.entity.User;
+import java.util.*;
 
+@Port
 public interface LoadUserPort {
     User loadUserById(FindByUserIdQuery query);
+
+    User loadUserByRole(FindUserByRoleQuery query);
+
+    List<User> loadUserByDeleteOption(FindUserByDeleteOptionQuery query);
 }

--- a/src/main/java/com/ftm/server/application/port/out/persistence/user/UpdatePostUserDomainPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/user/UpdatePostUserDomainPort.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.out.persistence.user;
+
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.Post;
+import java.util.List;
+
+@Port
+public interface UpdatePostUserDomainPort {
+    void updatePostListBySystemUser(List<Post> postList);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/user/UpdateUserPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/user/UpdateUserPort.java
@@ -4,6 +4,6 @@ import com.ftm.server.common.annotation.Port;
 import com.ftm.server.domain.entity.User;
 
 @Port
-public interface UpdateUserInfoPort {
-    void updateUserInfo(User user);
+public interface UpdateUserPort {
+    void updateUser(User user);
 }

--- a/src/main/java/com/ftm/server/application/query/FindUserByDeleteOptionQuery.java
+++ b/src/main/java/com/ftm/server/application/query/FindUserByDeleteOptionQuery.java
@@ -1,0 +1,14 @@
+package com.ftm.server.application.query;
+
+import java.time.LocalDate;
+import lombok.Data;
+
+@Data
+public class FindUserByDeleteOptionQuery {
+    private final Boolean isDeleted;
+    private final LocalDate deletedAt;
+
+    public static FindUserByDeleteOptionQuery of(Boolean isDeleted, LocalDate deletedAt) {
+        return new FindUserByDeleteOptionQuery(isDeleted, deletedAt);
+    }
+}

--- a/src/main/java/com/ftm/server/application/query/FindUserByRoleQuery.java
+++ b/src/main/java/com/ftm/server/application/query/FindUserByRoleQuery.java
@@ -1,0 +1,13 @@
+package com.ftm.server.application.query;
+
+import com.ftm.server.domain.enums.UserRole;
+import lombok.Data;
+
+@Data
+public class FindUserByRoleQuery {
+    private final UserRole userRole;
+
+    public static FindUserByRoleQuery of(UserRole userRole) {
+        return new FindUserByRoleQuery(userRole);
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/user/UpdateUserInfoService.java
+++ b/src/main/java/com/ftm/server/application/service/user/UpdateUserInfoService.java
@@ -5,7 +5,7 @@ import com.ftm.server.application.port.in.user.UpdateUserInfoUseCase;
 import com.ftm.server.application.port.out.persistence.user.LoadUserImagePort;
 import com.ftm.server.application.port.out.persistence.user.LoadUserPort;
 import com.ftm.server.application.port.out.persistence.user.UpdateUserImagePort;
-import com.ftm.server.application.port.out.persistence.user.UpdateUserInfoPort;
+import com.ftm.server.application.port.out.persistence.user.UpdateUserPort;
 import com.ftm.server.application.port.out.s3.S3ImageDeletePort;
 import com.ftm.server.application.port.out.s3.S3UserImageUploadPort;
 import com.ftm.server.application.port.out.transcation.AfterCommitExecutorPort;
@@ -28,7 +28,7 @@ public class UpdateUserInfoService implements UpdateUserInfoUseCase {
     private final LoadUserImagePort loadUserImagePort;
     private final LoadUserPort loadUserPort;
 
-    private final UpdateUserInfoPort updateUserInfoPort;
+    private final UpdateUserPort updateUserPort;
     private final UpdateUserImagePort updateUserImagePort;
 
     private final S3UserImageUploadPort s3UserImageUploadPort;
@@ -87,7 +87,7 @@ public class UpdateUserInfoService implements UpdateUserInfoUseCase {
             }
         }
 
-        updateUserInfoPort.updateUserInfo(user);
+        updateUserPort.updateUser(user);
         updateUserImagePort.updateUserImage(userImage);
 
         return UserWithImageVo.of(user, userImage);

--- a/src/main/java/com/ftm/server/application/service/user/UserExitService.java
+++ b/src/main/java/com/ftm/server/application/service/user/UserExitService.java
@@ -1,0 +1,53 @@
+package com.ftm.server.application.service.user;
+
+import com.ftm.server.application.command.user.DeleteUserByIdCommand;
+import com.ftm.server.application.port.in.user.UserExitUseCase;
+import com.ftm.server.application.port.out.persistence.user.LoadPostUserDomainPort;
+import com.ftm.server.application.port.out.persistence.user.LoadUserPort;
+import com.ftm.server.application.port.out.persistence.user.UpdatePostUserDomainPort;
+import com.ftm.server.application.port.out.persistence.user.UpdateUserPort;
+import com.ftm.server.application.query.FindByUserIdQuery;
+import com.ftm.server.application.query.FindUserByRoleQuery;
+import com.ftm.server.domain.entity.Post;
+import com.ftm.server.domain.entity.User;
+import com.ftm.server.domain.enums.UserRole;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserExitService implements UserExitUseCase {
+
+    private final LoadUserPort loadUserPort;
+    private final LoadPostUserDomainPort loadPostPort;
+
+    private final UpdateUserPort updateUserPort;
+    private final UpdatePostUserDomainPort updatePostPort;
+
+    @Transactional
+    @Override
+    public void execute(DeleteUserByIdCommand query) {
+
+        // user soft delete
+        User user = loadUserPort.loadUserById(FindByUserIdQuery.of(query.getUserId()));
+        user.updateIsDeleted(true);
+        user.updateDeletedAt(LocalDateTime.now());
+        updateUserPort.updateUser(user);
+
+        // user가 쓴 게시글의 작성자를 익명 사용자로 변경
+        List<Post> postList = loadPostPort.loadPostListByUser(FindByUserIdQuery.of(user.getId()));
+        if (!postList.isEmpty()) {
+            // 익명 사용자 조회
+            User systemUser = loadUserPort.loadUserByRole(FindUserByRoleQuery.of(UserRole.SYSTEM));
+            Long systemUserId = systemUser.getId();
+            // post update
+            postList.forEach(p -> p.updateUserId(systemUserId));
+            updatePostPort.updatePostListBySystemUser(postList);
+        }
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/user/UserHardDeleteService.java
+++ b/src/main/java/com/ftm/server/application/service/user/UserHardDeleteService.java
@@ -1,0 +1,66 @@
+package com.ftm.server.application.service.user;
+
+import com.ftm.server.application.command.user.DeleteAllUserByIdListCommand;
+import com.ftm.server.application.command.user.DeleteBookmarkByUserIdCommand;
+import com.ftm.server.application.command.user.DeleteGroomingTestResultByUserIdCommand;
+import com.ftm.server.application.command.user.DeleteUserImageByUserIdCommand;
+import com.ftm.server.application.port.in.user.UserHardDeleteUseCase;
+import com.ftm.server.application.port.out.persistence.user.*;
+import com.ftm.server.application.port.out.s3.S3ImageDeletePort;
+import com.ftm.server.application.port.out.transcation.AfterCommitExecutorPort;
+import com.ftm.server.application.query.FindUserByDeleteOptionQuery;
+import com.ftm.server.domain.entity.User;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class UserHardDeleteService implements UserHardDeleteUseCase {
+
+    private final LoadUserPort loadUserPort;
+
+    private final DeleteBookmarkPort deleteBookmarkPort;
+    private final DeleteGroomingTestResultPort deleteGroomingTestResultPort;
+    private final DeleteUserImagePort deleteUserImagePort;
+    private final DeleteUserPort deleteUserPort;
+
+    private final AfterCommitExecutorPort afterCommitExecutorPort;
+    private final S3ImageDeletePort s3ImageDeletePort;
+
+    @Override
+    @Transactional
+    public void execute() {
+
+        // 삭제 대상 user 조회 : 이미 삭제가 된 회원 중 30일이 지난 경우 hard delete 대상
+        List<Long> deletedUserIdList =
+                loadUserPort
+                        .loadUserByDeleteOption(
+                                FindUserByDeleteOptionQuery.of(true, LocalDate.now().minusDays(30)))
+                        .stream()
+                        .map(User::getId)
+                        .toList();
+
+        // user 관련 엔티티 모두 삭제 (batch 삭제 진행)
+        // 1. 북마크 삭제
+        deleteBookmarkPort.deleteBookmarkByUserList(
+                DeleteBookmarkByUserIdCommand.of(deletedUserIdList));
+        // 2. 그루밍 결과 삭제
+        deleteGroomingTestResultPort.deleteGroomingTestResultByUserList(
+                DeleteGroomingTestResultByUserIdCommand.of(deletedUserIdList));
+        // 3. user 이미지 삭제
+        List<String> imageKeyList =
+                deleteUserImagePort.deleteUserImageByUserList(
+                        DeleteUserImageByUserIdCommand.of(deletedUserIdList));
+        afterCommitExecutorPort.doAfterCommit(
+                () ->
+                        s3ImageDeletePort.deleteImages(
+                                imageKeyList)); // transaction commit 이후에 s3에 이미지 삭제 요청
+        // 4. user 삭제
+        deleteUserPort.deleteAllUserByIdList(DeleteAllUserByIdListCommand.of(deletedUserIdList));
+    }
+}

--- a/src/main/java/com/ftm/server/domain/entity/Post.java
+++ b/src/main/java/com/ftm/server/domain/entity/Post.java
@@ -121,4 +121,8 @@ public class Post extends BaseTime {
             throw new CustomException(ErrorResponseCode.UNAUTHORIZED_POST_ACCESS);
         }
     }
+
+    public void updateUserId(Long userId) {
+        this.userId = userId;
+    }
 }

--- a/src/main/java/com/ftm/server/domain/entity/User.java
+++ b/src/main/java/com/ftm/server/domain/entity/User.java
@@ -165,4 +165,12 @@ public class User extends BaseTime {
     public void updateAge(AgeGroup ageGroup) {
         this.ageGroup = ageGroup;
     }
+
+    public void updateIsDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
+    public void updateDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 }

--- a/src/main/java/com/ftm/server/domain/enums/UserRole.java
+++ b/src/main/java/com/ftm/server/domain/enums/UserRole.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum UserRole {
     ADMIN("admin"),
     USER("일반 user"),
-    GUEST("방문자");
+    GUEST("방문자"),
+    SYSTEM("시스템 용 사용자");
 
     private final String value;
 

--- a/src/test/java/com/ftm/server/user/UserExitTest.java
+++ b/src/test/java/com/ftm/server/user/UserExitTest.java
@@ -1,0 +1,70 @@
+package com.ftm.server.user;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.ftm.server.BaseTest;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class UserExitTest extends BaseTest {
+    private final List<FieldDescriptor> responseFieldDescriptors =
+            List.of(
+                    fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 상태"),
+                    fieldWithPath("code").type(JsonFieldType.STRING).description("상태 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+                    fieldWithPath("data")
+                            .type(JsonFieldType.OBJECT)
+                            .optional()
+                            .description("data"));
+
+    private ResultActions getResultActions(MockHttpSession session) throws Exception {
+        return mockMvc.perform( // api 실행
+                RestDocumentationRequestBuilders.delete("/api/users").session(session));
+    }
+
+    // 문서화 반환 함수
+    private RestDocumentationResultHandler getDocument(Integer identifier) {
+        return document(
+                "userExit/" + identifier,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint(), getModifiedHeader()),
+                responseFields(responseFieldDescriptors),
+                resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .summary("회원 탈퇴 api")
+                                .description("회원 탈퇴를 진행합니다.")
+                                .responseFields(responseFieldDescriptors)
+                                .build()));
+    }
+
+    @Test
+    @Transactional
+    void 회원탈퇴_성공() throws Exception {
+        // given
+        MockHttpSession session = createUserAndLogin();
+
+        // when
+        ResultActions resultActions = getResultActions(session);
+
+        // then
+        resultActions.andExpect(status().isOk());
+
+        // documentation
+        resultActions.andDo(getDocument(1));
+    }
+}

--- a/src/test/java/com/ftm/server/user/UserHardDeleteTest.java
+++ b/src/test/java/com/ftm/server/user/UserHardDeleteTest.java
@@ -1,0 +1,53 @@
+package com.ftm.server.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.out.persistence.repository.UserRepository;
+import com.ftm.server.application.port.in.user.UserHardDeleteUseCase;
+import com.ftm.server.application.port.out.persistence.user.UpdateUserPort;
+import com.ftm.server.application.port.out.s3.S3ImageDeletePort;
+import com.ftm.server.domain.entity.User;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@SpringBootTest
+public class UserHardDeleteTest extends BaseTest {
+
+    @Autowired private UserHardDeleteUseCase userHardDeleteUseCase;
+
+    @Autowired private UserRepository userRepository; // 실제 JPA 리포지토리
+
+    @Autowired private UpdateUserPort updateUserPort;
+
+    @MockitoSpyBean private S3ImageDeletePort s3ImageDeletePort;
+
+    @Test
+    void hard_delete_성공() {
+        // given
+        User user1 = createTestUser("test1", "qwe123@");
+        User user2 = createTestUser("test2", "qwe123@");
+
+        user1.updateIsDeleted(true);
+        user1.updateDeletedAt(LocalDateTime.now().minusDays(30));
+        user2.updateIsDeleted(true);
+        user2.updateDeletedAt(LocalDateTime.now().minusDays(30));
+
+        updateUserPort.updateUser(user1);
+        updateUserPort.updateUser(user2);
+        userRepository.flush();
+
+        doNothing().when(s3ImageDeletePort); // stub 생성, s3 직접 호출 x
+
+        // when
+        userHardDeleteUseCase.execute();
+
+        // then
+        assertThat(userRepository.findById(user1.getId())).isEmpty();
+        assertThat(userRepository.findById(user2.getId())).isEmpty();
+    }
+}


### PR DESCRIPTION

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #107

## 📌 작업 내용 및 특이사항
- soft delete : user delete 상태 변경 & user가 작성한 게시글을 SYSTEM 익명 유저로 변경(닉네임 : (알수없음))
- hard delete : user, 북마크, 이미지, 그루밍 테스트 결과를 회원 탈퇴 30일 이후에 삭제되도록 스케줄러 구현
- hard delete는 usecase로 구현하고, 외부 scheduler 계층에서 usecase 호출하도록 구현
- 해당 usecase는 문서화하지 않고 통합 테스트 코드 작성

## 🔍 참고사항

- port implement 하는 구현체가 점점 커지는 것 같습니다. 한번 분리하는게 필요할 것 같습니다. 

## 📚 기타

-