### PR TITLE
chore: Security cors 허용 경로에 클라이언트 배포 경로 추가

### DIFF
--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
                     "https://dev-api.fittheman.site", // 개발 환경 서버 도메인
                     "http://localhost:3000", // 로컬 환경 클라이언트 도메인
                     "https://localhost:3000", // 로컬 환경 https 클라이언트 도메인
-                    "https://fittheman.site"); // 개발 환경 클라이언트 도메인
+                    "https://ftm-client.vercel.app", // 개발 환경 클라이언트 도메인
+                    "https://fittheman.site"); // 클라이언트 도메인
 
     private static final String[] GET_ANONYMOUS_MATCHERS = {
         "/api/users/email/duplication",


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #110 

## 📌 작업 내용 및 특이사항

- Spring Security cors 허용 경로에 클라이언트 배포 경로 추가했습니다 (https://ftm-client.vercel.app)

## 🔍 참고사항

-

## 📚 기타

-