### PR TITLE
feat: 관리자 그루밍 테스트 질문, 답변 생성/수정/삭제 api 구현

### DIFF
--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/answer/DeleteGroomingTestAnswerController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/answer/DeleteGroomingTestAnswerController.java
@@ -1,0 +1,26 @@
+package com.ftm.server.adapter.in.web.grooming.controller.answer;
+
+import com.ftm.server.application.command.grooming.answer.DeleteGroomingTestAnswerCommand;
+import com.ftm.server.application.port.in.grooming.answer.DeleteGroomingTestAnswerUseCase;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class DeleteGroomingTestAnswerController {
+
+    private final DeleteGroomingTestAnswerUseCase deleteGroomingTestAnswerUseCase;
+
+    @DeleteMapping("/api/grooming/tests/answers/{answerId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAnswer(@PathVariable Long answerId) {
+        deleteGroomingTestAnswerUseCase.execute(DeleteGroomingTestAnswerCommand.of(answerId));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessResponseCode.OK));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/answer/SaveGroomingTestAnswerController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/answer/SaveGroomingTestAnswerController.java
@@ -1,0 +1,33 @@
+package com.ftm.server.adapter.in.web.grooming.controller.answer;
+
+import com.ftm.server.adapter.in.web.grooming.dto.request.SaveGroomingTestAnswerRequest;
+import com.ftm.server.application.command.grooming.answer.SaveGroomingTestAnswerCommand;
+import com.ftm.server.application.port.in.grooming.answer.SaveGroomingTestAnswerUseCase;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SaveGroomingTestAnswerController {
+
+    private final SaveGroomingTestAnswerUseCase saveGroomingTestAnswerUseCase;
+
+    @PostMapping("/api/grooming/tests/questions/{questionsId}/answers")
+    public ResponseEntity<ApiResponse<Void>> saveAnswer(
+            @PathVariable Long questionsId,
+            @RequestBody @Valid SaveGroomingTestAnswerRequest request) {
+        saveGroomingTestAnswerUseCase.execute(
+                SaveGroomingTestAnswerCommand.of(
+                        questionsId, request.getAnswer(), request.getScore()));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessResponseCode.CREATED));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/answer/UpdateGroomingTestAnswerController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/answer/UpdateGroomingTestAnswerController.java
@@ -1,0 +1,34 @@
+package com.ftm.server.adapter.in.web.grooming.controller.answer;
+
+import com.ftm.server.adapter.in.web.grooming.dto.request.UpdateGroomingTestAnswerRequest;
+import com.ftm.server.application.command.grooming.answer.UpdateGroomingTestAnswerCommand;
+import com.ftm.server.application.port.in.grooming.answer.UpdateGroomingTestAnswerUseCase;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UpdateGroomingTestAnswerController {
+
+    private final UpdateGroomingTestAnswerUseCase updateGroomingTestAnswerUseCase;
+
+    @PatchMapping("/api/grooming/tests/answers/{answerId}")
+    public ResponseEntity<ApiResponse<Void>> updateAnswer(
+            @PathVariable Long answerId, @RequestBody UpdateGroomingTestAnswerRequest request) {
+        updateGroomingTestAnswerUseCase.execute(
+                UpdateGroomingTestAnswerCommand.of(
+                        answerId,
+                        request.getQuestionId(),
+                        request.getAnswer(),
+                        request.getScore()));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessResponseCode.OK));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/question/DeleteGroomingTestQuestionController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/question/DeleteGroomingTestQuestionController.java
@@ -1,0 +1,26 @@
+package com.ftm.server.adapter.in.web.grooming.controller.question;
+
+import com.ftm.server.application.command.grooming.DeleteGroomingTestQuestionCommand;
+import com.ftm.server.application.port.in.grooming.question.DeleteGroomingTestQuestionUseCase;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class DeleteGroomingTestQuestionController {
+
+    private final DeleteGroomingTestQuestionUseCase deleteGroomingTestQuestionUseCase;
+
+    @DeleteMapping("/api/grooming/tests/questions/{questionId}")
+    public ResponseEntity<ApiResponse<Void>> deleteQuestion(@PathVariable Long questionId) {
+        deleteGroomingTestQuestionUseCase.execute(DeleteGroomingTestQuestionCommand.of(questionId));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessResponseCode.OK));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/question/SaveGroomingTestQuestionController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/question/SaveGroomingTestQuestionController.java
@@ -1,0 +1,31 @@
+package com.ftm.server.adapter.in.web.grooming.controller.question;
+
+import com.ftm.server.adapter.in.web.grooming.dto.request.SaveGroomingTestQuestionRequest;
+import com.ftm.server.application.command.grooming.SaveGroomingTestQuestionCommand;
+import com.ftm.server.application.port.in.grooming.question.SaveGroomingTestQuestionUseCase;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SaveGroomingTestQuestionController {
+
+    private final SaveGroomingTestQuestionUseCase saveGroomingTestQuestionUseCase;
+
+    @PostMapping("/api/grooming/tests/questions")
+    public ResponseEntity<ApiResponse<Void>> saveQuestion(
+            @RequestBody @Valid SaveGroomingTestQuestionRequest request) {
+        saveGroomingTestQuestionUseCase.execute(
+                SaveGroomingTestQuestionCommand.of(
+                        request.getGroomingCategory(), request.getQuestion()));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessResponseCode.CREATED));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/question/UpdateGroomingTestQuestionController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/question/UpdateGroomingTestQuestionController.java
@@ -1,0 +1,31 @@
+package com.ftm.server.adapter.in.web.grooming.controller.question;
+
+import com.ftm.server.adapter.in.web.grooming.dto.request.UpdateGroomingTestQuestionRequest;
+import com.ftm.server.application.command.grooming.UpdateGroomingTestQuestionCommand;
+import com.ftm.server.application.port.in.grooming.question.UpdateGroomingTestQuestionUseCase;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UpdateGroomingTestQuestionController {
+
+    private final UpdateGroomingTestQuestionUseCase updateGroomingTestQuestionUseCase;
+
+    @PatchMapping("/api/grooming/tests/questions/{questionId}")
+    public ResponseEntity<ApiResponse<Void>> updateQuestion(
+            @PathVariable Long questionId, @RequestBody UpdateGroomingTestQuestionRequest request) {
+        updateGroomingTestQuestionUseCase.execute(
+                UpdateGroomingTestQuestionCommand.of(
+                        questionId, request.getGroomingCategory(), request.getQuestion()));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessResponseCode.OK));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/SaveGroomingTestAnswerRequest.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/SaveGroomingTestAnswerRequest.java
@@ -1,0 +1,16 @@
+package com.ftm.server.adapter.in.web.grooming.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SaveGroomingTestAnswerRequest {
+
+    @NotEmpty private String answer;
+
+    @Min(0)
+    private Integer score;
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/SaveGroomingTestQuestionRequest.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/SaveGroomingTestQuestionRequest.java
@@ -1,0 +1,15 @@
+package com.ftm.server.adapter.in.web.grooming.dto.request;
+
+import com.ftm.server.domain.enums.GroomingCategory;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SaveGroomingTestQuestionRequest {
+
+    @NotNull private GroomingCategory groomingCategory;
+    @NotEmpty private String question;
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/UpdateGroomingTestAnswerRequest.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/UpdateGroomingTestAnswerRequest.java
@@ -1,0 +1,13 @@
+package com.ftm.server.adapter.in.web.grooming.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateGroomingTestAnswerRequest {
+
+    private Long questionId;
+    private String answer;
+    private Integer score;
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/UpdateGroomingTestQuestionRequest.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/UpdateGroomingTestQuestionRequest.java
@@ -1,0 +1,13 @@
+package com.ftm.server.adapter.in.web.grooming.dto.request;
+
+import com.ftm.server.domain.enums.GroomingCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateGroomingTestQuestionRequest {
+
+    private GroomingCategory groomingCategory;
+    private String question;
+}

--- a/src/main/java/com/ftm/server/adapter/out/cache/CaffeineCacheAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/cache/CaffeineCacheAdapter.java
@@ -7,6 +7,7 @@ import com.ftm.server.adapter.out.persistence.mapper.GroomingTestAnswerMapper;
 import com.ftm.server.adapter.out.persistence.mapper.GroomingTestQuestionMapper;
 import com.ftm.server.adapter.out.persistence.repository.GroomingTestAnswerRepository;
 import com.ftm.server.adapter.out.persistence.repository.GroomingTestQuestionRepository;
+import com.ftm.server.application.port.out.cache.InvalidGroomingTestsWithCachePort;
 import com.ftm.server.application.port.out.cache.LoadGroomingTestsWithCachePort;
 import com.ftm.server.application.vo.grooming.GroomingTestAnswerInfoVo;
 import com.ftm.server.application.vo.grooming.GroomingTestQuestionWithAnswersVo;
@@ -19,12 +20,14 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 
 @Slf4j
 @Adapter
 @RequiredArgsConstructor
-public class CaffeineCacheAdapter implements LoadGroomingTestsWithCachePort {
+public class CaffeineCacheAdapter
+        implements LoadGroomingTestsWithCachePort, InvalidGroomingTestsWithCachePort {
 
     private final GroomingTestQuestionRepository groomingTestQuestionRepository;
     private final GroomingTestAnswerRepository groomingTestAnswerRepository;
@@ -68,4 +71,8 @@ public class CaffeineCacheAdapter implements LoadGroomingTestsWithCachePort {
                                                 question.getId(), List.of())))
                 .collect(Collectors.toCollection(ArrayList::new));
     }
+
+    @CacheEvict(value = GROOMING_TESTS_INFO_CACHE_NAME, key = GROOMING_TESTS_INFO_CACHE_KEY_ALL)
+    @Override
+    public void invalidGroomingTestsCache() {}
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/grooming/GroomingDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/grooming/GroomingDomainPersistenceAdapter.java
@@ -33,7 +33,9 @@ public class GroomingDomainPersistenceAdapter
                 SaveGroomingTestQuestionPort,
                 UpdateGroomingTestQuestionPort,
                 DeleteGroomingTestQuestionPort,
-                DeleteGroomingTestAnswerPort {
+                DeleteGroomingTestAnswerPort,
+                SaveGroomingTestAnswerPort,
+                UpdateGroomingTestAnswerPort {
 
     // Repository
     private final GroomingTestQuestionRepository groomingTestQuestionRepository;
@@ -70,6 +72,13 @@ public class GroomingDomainPersistenceAdapter
         return answers.stream()
                 .map(groomingTestAnswerMapper::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<GroomingTestAnswer> loadGroomingTestAnswerById(FindByIdQuery query) {
+        return groomingTestAnswerRepository
+                .findById(query.getId())
+                .map(groomingTestAnswerMapper::toDomain);
     }
 
     @Override
@@ -177,5 +186,57 @@ public class GroomingDomainPersistenceAdapter
     @Override
     public void deleteGroomingTestAnswersByQuestionId(Long questionId) {
         groomingTestAnswerRepository.deleteAllByGroomingTestQuestionId(questionId);
+    }
+
+    @Override
+    public void deleteGroomingTestAnswerById(Long id) {
+        groomingTestAnswerRepository.deleteById(id);
+    }
+
+    @Override
+    public void saveGroomingTestAnswer(GroomingTestAnswer groomingTestAnswer) {
+        GroomingTestQuestionJpaEntity groomingTestQuestionJpaEntity =
+                groomingTestQuestionRepository
+                        .findById(groomingTestAnswer.getGroomingTestQuestionId())
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorResponseCode
+                                                        .GROOMING_TEST_QUESTION_NOT_FOUND));
+
+        groomingTestAnswerRepository.save(
+                groomingTestAnswerMapper.toJpaEntity(
+                        groomingTestAnswer, groomingTestQuestionJpaEntity));
+    }
+
+    @Override
+    public void updateGroomingTestAnswer(
+            GroomingTestAnswer groomingTestAnswer, boolean isQuestionModified) {
+        GroomingTestAnswerJpaEntity groomingTestAnswerJpaEntity =
+                groomingTestAnswerRepository
+                        .findById(groomingTestAnswer.getId())
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorResponseCode.GROOMING_TEST_ANSWER_NOT_FOUND));
+
+        // 답변이 속한 질문을 수정했을 경우, 질문 정보까지 함께 수정
+        if (isQuestionModified) {
+            GroomingTestQuestionJpaEntity groomingTestQuestionJpaEntity =
+                    groomingTestQuestionRepository
+                            .findById(groomingTestAnswer.getGroomingTestQuestionId())
+                            .orElseThrow(
+                                    () ->
+                                            new CustomException(
+                                                    ErrorResponseCode
+                                                            .GROOMING_TEST_QUESTION_NOT_FOUND));
+
+            groomingTestAnswerJpaEntity.updateGroomingTestAnswerForDomainEntity(
+                    groomingTestQuestionJpaEntity, groomingTestAnswer);
+            return;
+        }
+
+        // 질문 정보를 제외한 나머지 필드 수정
+        groomingTestAnswerJpaEntity.updateGroomingTestAnswerForDomainEntity(groomingTestAnswer);
     }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/grooming/GroomingDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/grooming/GroomingDomainPersistenceAdapter.java
@@ -29,7 +29,11 @@ public class GroomingDomainPersistenceAdapter
                 SaveGroomingTestResultPort,
                 LoadGroomingLevelPort,
                 UpdateUserForGroomingPort,
-                LoadGroomingTestResultPort {
+                LoadGroomingTestResultPort,
+                SaveGroomingTestQuestionPort,
+                UpdateGroomingTestQuestionPort,
+                DeleteGroomingTestQuestionPort,
+                DeleteGroomingTestAnswerPort {
 
     // Repository
     private final GroomingTestQuestionRepository groomingTestQuestionRepository;
@@ -51,6 +55,13 @@ public class GroomingDomainPersistenceAdapter
         return questions.stream()
                 .map(groomingTestQuestionMapper::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<GroomingTestQuestion> loadGroomingTestQuestionById(FindByIdQuery query) {
+        return groomingTestQuestionRepository
+                .findById(query.getId())
+                .map(groomingTestQuestionMapper::toDomain);
     }
 
     @Override
@@ -135,5 +146,36 @@ public class GroomingDomainPersistenceAdapter
                 groomingTestResultRepository.loadByUserIdAndTestedAt(query);
 
         return results.stream().map(groomingTestResultMapper::toDomainEntity).toList();
+    }
+
+    @Override
+    public void saveGroomingTestQuestion(GroomingTestQuestion groomingTestQuestion) {
+        groomingTestQuestionRepository.save(
+                groomingTestQuestionMapper.toJpaEntity(groomingTestQuestion));
+    }
+
+    @Override
+    public void updateGroomingTestQuestion(GroomingTestQuestion groomingTestQuestion) {
+        GroomingTestQuestionJpaEntity groomingTestQuestionJpaEntity =
+                groomingTestQuestionRepository
+                        .findById(groomingTestQuestion.getId())
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorResponseCode
+                                                        .GROOMING_TEST_QUESTION_NOT_FOUND));
+
+        groomingTestQuestionJpaEntity.updateGroomingTestQuestionForDomainEntity(
+                groomingTestQuestion);
+    }
+
+    @Override
+    public void deleteGroomingTestQuestionById(Long id) {
+        groomingTestQuestionRepository.deleteById(id);
+    }
+
+    @Override
+    public void deleteGroomingTestAnswersByQuestionId(Long questionId) {
+        groomingTestAnswerRepository.deleteAllByGroomingTestQuestionId(questionId);
     }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/model/GroomingTestAnswerJpaEntity.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/model/GroomingTestAnswerJpaEntity.java
@@ -43,4 +43,17 @@ public class GroomingTestAnswerJpaEntity extends BaseTimeJpaEntity {
                 .score(groomingTestAnswer.getScore())
                 .build();
     }
+
+    public void updateGroomingTestAnswerForDomainEntity(
+            GroomingTestQuestionJpaEntity groomingTestQuestionJpaEntity,
+            GroomingTestAnswer groomingTestAnswer) {
+        this.groomingTestQuestion = groomingTestQuestionJpaEntity;
+        this.answer = groomingTestAnswer.getAnswer();
+        this.score = groomingTestAnswer.getScore();
+    }
+
+    public void updateGroomingTestAnswerForDomainEntity(GroomingTestAnswer groomingTestAnswer) {
+        this.answer = groomingTestAnswer.getAnswer();
+        this.score = groomingTestAnswer.getScore();
+    }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/model/GroomingTestQuestionJpaEntity.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/model/GroomingTestQuestionJpaEntity.java
@@ -39,4 +39,10 @@ public class GroomingTestQuestionJpaEntity extends BaseTimeJpaEntity {
                 .question(groomingTestQuestion.getQuestion())
                 .build();
     }
+
+    public void updateGroomingTestQuestionForDomainEntity(
+            GroomingTestQuestion groomingTestQuestion) {
+        this.groomingCategory = groomingTestQuestion.getGroomingCategory();
+        this.question = groomingTestQuestion.getQuestion();
+    }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/GroomingTestAnswerRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/GroomingTestAnswerRepository.java
@@ -2,6 +2,14 @@ package com.ftm.server.adapter.out.persistence.repository;
 
 import com.ftm.server.adapter.out.persistence.model.GroomingTestAnswerJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GroomingTestAnswerRepository
-        extends JpaRepository<GroomingTestAnswerJpaEntity, Long> {}
+        extends JpaRepository<GroomingTestAnswerJpaEntity, Long> {
+
+    @Modifying
+    @Query(
+            "DELETE FROM GroomingTestAnswerJpaEntity gta WHERE gta.groomingTestQuestion.id = (:questionId)")
+    void deleteAllByGroomingTestQuestionId(Long questionId);
+}

--- a/src/main/java/com/ftm/server/application/command/grooming/DeleteGroomingTestQuestionCommand.java
+++ b/src/main/java/com/ftm/server/application/command/grooming/DeleteGroomingTestQuestionCommand.java
@@ -1,0 +1,17 @@
+package com.ftm.server.application.command.grooming;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteGroomingTestQuestionCommand {
+
+    private final Long id;
+
+    private DeleteGroomingTestQuestionCommand(Long id) {
+        this.id = id;
+    }
+
+    public static DeleteGroomingTestQuestionCommand of(Long id) {
+        return new DeleteGroomingTestQuestionCommand(id);
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/grooming/SaveGroomingTestQuestionCommand.java
+++ b/src/main/java/com/ftm/server/application/command/grooming/SaveGroomingTestQuestionCommand.java
@@ -1,0 +1,21 @@
+package com.ftm.server.application.command.grooming;
+
+import com.ftm.server.domain.enums.GroomingCategory;
+import lombok.Getter;
+
+@Getter
+public class SaveGroomingTestQuestionCommand {
+
+    private final GroomingCategory groomingCategory;
+    private final String question;
+
+    private SaveGroomingTestQuestionCommand(GroomingCategory groomingCategory, String question) {
+        this.groomingCategory = groomingCategory;
+        this.question = question;
+    }
+
+    public static SaveGroomingTestQuestionCommand of(
+            GroomingCategory groomingCategory, String question) {
+        return new SaveGroomingTestQuestionCommand(groomingCategory, question);
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/grooming/UpdateGroomingTestQuestionCommand.java
+++ b/src/main/java/com/ftm/server/application/command/grooming/UpdateGroomingTestQuestionCommand.java
@@ -1,0 +1,24 @@
+package com.ftm.server.application.command.grooming;
+
+import com.ftm.server.domain.enums.GroomingCategory;
+import lombok.Getter;
+
+@Getter
+public class UpdateGroomingTestQuestionCommand {
+
+    private final Long id;
+    private final GroomingCategory groomingCategory;
+    private final String question;
+
+    private UpdateGroomingTestQuestionCommand(
+            Long id, GroomingCategory groomingCategory, String question) {
+        this.id = id;
+        this.groomingCategory = groomingCategory;
+        this.question = question;
+    }
+
+    public static UpdateGroomingTestQuestionCommand of(
+            Long id, GroomingCategory groomingCategory, String question) {
+        return new UpdateGroomingTestQuestionCommand(id, groomingCategory, question);
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/grooming/answer/DeleteGroomingTestAnswerCommand.java
+++ b/src/main/java/com/ftm/server/application/command/grooming/answer/DeleteGroomingTestAnswerCommand.java
@@ -1,0 +1,17 @@
+package com.ftm.server.application.command.grooming.answer;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteGroomingTestAnswerCommand {
+
+    private final Long id;
+
+    private DeleteGroomingTestAnswerCommand(Long id) {
+        this.id = id;
+    }
+
+    public static DeleteGroomingTestAnswerCommand of(Long id) {
+        return new DeleteGroomingTestAnswerCommand(id);
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/grooming/answer/SaveGroomingTestAnswerCommand.java
+++ b/src/main/java/com/ftm/server/application/command/grooming/answer/SaveGroomingTestAnswerCommand.java
@@ -1,0 +1,21 @@
+package com.ftm.server.application.command.grooming.answer;
+
+import lombok.Getter;
+
+@Getter
+public class SaveGroomingTestAnswerCommand {
+
+    private final Long questionId;
+    private final String answer;
+    private final Integer score;
+
+    private SaveGroomingTestAnswerCommand(Long questionId, String answer, Integer score) {
+        this.questionId = questionId;
+        this.answer = answer;
+        this.score = score;
+    }
+
+    public static SaveGroomingTestAnswerCommand of(Long questionId, String answer, Integer score) {
+        return new SaveGroomingTestAnswerCommand(questionId, answer, score);
+    }
+}

--- a/src/main/java/com/ftm/server/application/command/grooming/answer/UpdateGroomingTestAnswerCommand.java
+++ b/src/main/java/com/ftm/server/application/command/grooming/answer/UpdateGroomingTestAnswerCommand.java
@@ -1,0 +1,25 @@
+package com.ftm.server.application.command.grooming.answer;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateGroomingTestAnswerCommand {
+
+    private final Long id;
+    private final Long questionId;
+    private final String answer;
+    private final Integer score;
+
+    private UpdateGroomingTestAnswerCommand(
+            Long id, Long questionId, String answer, Integer score) {
+        this.id = id;
+        this.questionId = questionId;
+        this.answer = answer;
+        this.score = score;
+    }
+
+    public static UpdateGroomingTestAnswerCommand of(
+            Long id, Long questionId, String answer, Integer score) {
+        return new UpdateGroomingTestAnswerCommand(id, questionId, answer, score);
+    }
+}

--- a/src/main/java/com/ftm/server/application/port/in/grooming/answer/DeleteGroomingTestAnswerUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/grooming/answer/DeleteGroomingTestAnswerUseCase.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.in.grooming.answer;
+
+import com.ftm.server.application.command.grooming.answer.DeleteGroomingTestAnswerCommand;
+import com.ftm.server.common.annotation.UseCase;
+
+@UseCase
+public interface DeleteGroomingTestAnswerUseCase {
+
+    void execute(DeleteGroomingTestAnswerCommand command);
+}

--- a/src/main/java/com/ftm/server/application/port/in/grooming/answer/SaveGroomingTestAnswerUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/grooming/answer/SaveGroomingTestAnswerUseCase.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.in.grooming.answer;
+
+import com.ftm.server.application.command.grooming.answer.SaveGroomingTestAnswerCommand;
+import com.ftm.server.common.annotation.UseCase;
+
+@UseCase
+public interface SaveGroomingTestAnswerUseCase {
+
+    void execute(SaveGroomingTestAnswerCommand command);
+}

--- a/src/main/java/com/ftm/server/application/port/in/grooming/answer/UpdateGroomingTestAnswerUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/grooming/answer/UpdateGroomingTestAnswerUseCase.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.in.grooming.answer;
+
+import com.ftm.server.application.command.grooming.answer.UpdateGroomingTestAnswerCommand;
+import com.ftm.server.common.annotation.UseCase;
+
+@UseCase
+public interface UpdateGroomingTestAnswerUseCase {
+
+    void execute(UpdateGroomingTestAnswerCommand command);
+}

--- a/src/main/java/com/ftm/server/application/port/in/grooming/question/DeleteGroomingTestQuestionUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/grooming/question/DeleteGroomingTestQuestionUseCase.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.in.grooming.question;
+
+import com.ftm.server.application.command.grooming.DeleteGroomingTestQuestionCommand;
+import com.ftm.server.common.annotation.UseCase;
+
+@UseCase
+public interface DeleteGroomingTestQuestionUseCase {
+
+    void execute(DeleteGroomingTestQuestionCommand command);
+}

--- a/src/main/java/com/ftm/server/application/port/in/grooming/question/SaveGroomingTestQuestionUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/grooming/question/SaveGroomingTestQuestionUseCase.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.in.grooming.question;
+
+import com.ftm.server.application.command.grooming.SaveGroomingTestQuestionCommand;
+import com.ftm.server.common.annotation.UseCase;
+
+@UseCase
+public interface SaveGroomingTestQuestionUseCase {
+
+    void execute(SaveGroomingTestQuestionCommand command);
+}

--- a/src/main/java/com/ftm/server/application/port/in/grooming/question/UpdateGroomingTestQuestionUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/grooming/question/UpdateGroomingTestQuestionUseCase.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.in.grooming.question;
+
+import com.ftm.server.application.command.grooming.UpdateGroomingTestQuestionCommand;
+import com.ftm.server.common.annotation.UseCase;
+
+@UseCase
+public interface UpdateGroomingTestQuestionUseCase {
+
+    void execute(UpdateGroomingTestQuestionCommand command);
+}

--- a/src/main/java/com/ftm/server/application/port/out/cache/InvalidGroomingTestsWithCachePort.java
+++ b/src/main/java/com/ftm/server/application/port/out/cache/InvalidGroomingTestsWithCachePort.java
@@ -1,0 +1,9 @@
+package com.ftm.server.application.port.out.cache;
+
+import com.ftm.server.common.annotation.Port;
+
+@Port
+public interface InvalidGroomingTestsWithCachePort {
+
+    void invalidGroomingTestsCache();
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/grooming/DeleteGroomingTestAnswerPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/grooming/DeleteGroomingTestAnswerPort.java
@@ -1,0 +1,9 @@
+package com.ftm.server.application.port.out.persistence.grooming;
+
+import com.ftm.server.common.annotation.Port;
+
+@Port
+public interface DeleteGroomingTestAnswerPort {
+
+    void deleteGroomingTestAnswersByQuestionId(Long questionId);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/grooming/DeleteGroomingTestAnswerPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/grooming/DeleteGroomingTestAnswerPort.java
@@ -6,4 +6,6 @@ import com.ftm.server.common.annotation.Port;
 public interface DeleteGroomingTestAnswerPort {
 
     void deleteGroomingTestAnswersByQuestionId(Long questionId);
+
+    void deleteGroomingTestAnswerById(Long id);
 }

--- a/src/main/java/com/ftm/server/application/port/out/persistence/grooming/DeleteGroomingTestQuestionPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/grooming/DeleteGroomingTestQuestionPort.java
@@ -1,0 +1,9 @@
+package com.ftm.server.application.port.out.persistence.grooming;
+
+import com.ftm.server.common.annotation.Port;
+
+@Port
+public interface DeleteGroomingTestQuestionPort {
+
+    void deleteGroomingTestQuestionById(Long id);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/grooming/LoadGroomingTestAnswerPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/grooming/LoadGroomingTestAnswerPort.java
@@ -1,11 +1,15 @@
 package com.ftm.server.application.port.out.persistence.grooming;
 
+import com.ftm.server.application.query.FindByIdQuery;
 import com.ftm.server.common.annotation.Port;
 import com.ftm.server.domain.entity.GroomingTestAnswer;
 import java.util.List;
+import java.util.Optional;
 
 @Port
 public interface LoadGroomingTestAnswerPort {
 
     List<GroomingTestAnswer> loadGroomingTestAnswers();
+
+    Optional<GroomingTestAnswer> loadGroomingTestAnswerById(FindByIdQuery query);
 }

--- a/src/main/java/com/ftm/server/application/port/out/persistence/grooming/LoadGroomingTestQuestionPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/grooming/LoadGroomingTestQuestionPort.java
@@ -1,11 +1,15 @@
 package com.ftm.server.application.port.out.persistence.grooming;
 
+import com.ftm.server.application.query.FindByIdQuery;
 import com.ftm.server.common.annotation.Port;
 import com.ftm.server.domain.entity.GroomingTestQuestion;
 import java.util.List;
+import java.util.Optional;
 
 @Port
 public interface LoadGroomingTestQuestionPort {
 
     List<GroomingTestQuestion> loadGroomingTestQuestions();
+
+    Optional<GroomingTestQuestion> loadGroomingTestQuestionById(FindByIdQuery query);
 }

--- a/src/main/java/com/ftm/server/application/port/out/persistence/grooming/SaveGroomingTestAnswerPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/grooming/SaveGroomingTestAnswerPort.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.out.persistence.grooming;
+
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.GroomingTestAnswer;
+
+@Port
+public interface SaveGroomingTestAnswerPort {
+
+    void saveGroomingTestAnswer(GroomingTestAnswer groomingTestAnswer);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/grooming/SaveGroomingTestQuestionPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/grooming/SaveGroomingTestQuestionPort.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.out.persistence.grooming;
+
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.GroomingTestQuestion;
+
+@Port
+public interface SaveGroomingTestQuestionPort {
+
+    void saveGroomingTestQuestion(GroomingTestQuestion groomingTestQuestion);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/grooming/UpdateGroomingTestAnswerPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/grooming/UpdateGroomingTestAnswerPort.java
@@ -1,0 +1,11 @@
+package com.ftm.server.application.port.out.persistence.grooming;
+
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.GroomingTestAnswer;
+
+@Port
+public interface UpdateGroomingTestAnswerPort {
+
+    void updateGroomingTestAnswer(
+            GroomingTestAnswer groomingTestAnswer, boolean isQuestionModified);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/grooming/UpdateGroomingTestQuestionPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/grooming/UpdateGroomingTestQuestionPort.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.out.persistence.grooming;
+
+import com.ftm.server.common.annotation.Port;
+import com.ftm.server.domain.entity.GroomingTestQuestion;
+
+@Port
+public interface UpdateGroomingTestQuestionPort {
+
+    void updateGroomingTestQuestion(GroomingTestQuestion groomingTestQuestion);
+}

--- a/src/main/java/com/ftm/server/application/service/grooming/answer/DeleteGroomingTestAnswerService.java
+++ b/src/main/java/com/ftm/server/application/service/grooming/answer/DeleteGroomingTestAnswerService.java
@@ -1,0 +1,27 @@
+package com.ftm.server.application.service.grooming.answer;
+
+import com.ftm.server.application.command.grooming.answer.DeleteGroomingTestAnswerCommand;
+import com.ftm.server.application.port.in.grooming.answer.DeleteGroomingTestAnswerUseCase;
+import com.ftm.server.application.port.out.cache.InvalidGroomingTestsWithCachePort;
+import com.ftm.server.application.port.out.persistence.grooming.DeleteGroomingTestAnswerPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteGroomingTestAnswerService implements DeleteGroomingTestAnswerUseCase {
+
+    private final DeleteGroomingTestAnswerPort deleteGroomingTestAnswerPort;
+    private final InvalidGroomingTestsWithCachePort invalidGroomingTestsWithCachePort;
+
+    @Transactional
+    @Override
+    public void execute(DeleteGroomingTestAnswerCommand command) {
+        // 답변 삭제
+        deleteGroomingTestAnswerPort.deleteGroomingTestAnswerById(command.getId());
+
+        // 그루밍 테스트 캐싱 목록 초기화
+        invalidGroomingTestsWithCachePort.invalidGroomingTestsCache();
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/grooming/answer/SaveGroomingTestAnswerService.java
+++ b/src/main/java/com/ftm/server/application/service/grooming/answer/SaveGroomingTestAnswerService.java
@@ -1,0 +1,28 @@
+package com.ftm.server.application.service.grooming.answer;
+
+import com.ftm.server.application.command.grooming.answer.SaveGroomingTestAnswerCommand;
+import com.ftm.server.application.port.in.grooming.answer.SaveGroomingTestAnswerUseCase;
+import com.ftm.server.application.port.out.cache.InvalidGroomingTestsWithCachePort;
+import com.ftm.server.application.port.out.persistence.grooming.SaveGroomingTestAnswerPort;
+import com.ftm.server.domain.entity.GroomingTestAnswer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SaveGroomingTestAnswerService implements SaveGroomingTestAnswerUseCase {
+
+    private final SaveGroomingTestAnswerPort saveGroomingTestAnswerPort;
+    private final InvalidGroomingTestsWithCachePort invalidGroomingTestsWithCachePort;
+
+    @Transactional
+    @Override
+    public void execute(SaveGroomingTestAnswerCommand command) {
+        GroomingTestAnswer newAnswer = GroomingTestAnswer.create(command);
+        saveGroomingTestAnswerPort.saveGroomingTestAnswer(newAnswer);
+
+        // 그루밍 테스트 캐싱 목록 초기화
+        invalidGroomingTestsWithCachePort.invalidGroomingTestsCache();
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/grooming/answer/UpdateGroomingTestAnswerService.java
+++ b/src/main/java/com/ftm/server/application/service/grooming/answer/UpdateGroomingTestAnswerService.java
@@ -1,0 +1,45 @@
+package com.ftm.server.application.service.grooming.answer;
+
+import com.ftm.server.application.command.grooming.answer.UpdateGroomingTestAnswerCommand;
+import com.ftm.server.application.port.in.grooming.answer.UpdateGroomingTestAnswerUseCase;
+import com.ftm.server.application.port.out.cache.InvalidGroomingTestsWithCachePort;
+import com.ftm.server.application.port.out.persistence.grooming.LoadGroomingTestAnswerPort;
+import com.ftm.server.application.port.out.persistence.grooming.UpdateGroomingTestAnswerPort;
+import com.ftm.server.application.query.FindByIdQuery;
+import com.ftm.server.common.exception.CustomException;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.entity.GroomingTestAnswer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateGroomingTestAnswerService implements UpdateGroomingTestAnswerUseCase {
+
+    private final LoadGroomingTestAnswerPort loadGroomingTestAnswerPort;
+    private final UpdateGroomingTestAnswerPort updateGroomingTestAnswerPort;
+    private final InvalidGroomingTestsWithCachePort invalidGroomingTestsWithCachePort;
+
+    @Transactional
+    @Override
+    public void execute(UpdateGroomingTestAnswerCommand command) {
+        GroomingTestAnswer answer =
+                loadGroomingTestAnswerPort
+                        .loadGroomingTestAnswerById(FindByIdQuery.of(command.getId()))
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorResponseCode.GROOMING_TEST_ANSWER_NOT_FOUND));
+
+        // 답변이 속한 질문 변경 여부
+        boolean isQuestionModified = command.getQuestionId() != null;
+
+        // 답변 업데이트
+        answer.update(command);
+        updateGroomingTestAnswerPort.updateGroomingTestAnswer(answer, isQuestionModified);
+
+        // 그루밍 테스트 캐싱 목록 초기화
+        invalidGroomingTestsWithCachePort.invalidGroomingTestsCache();
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/grooming/question/DeleteGroomingTestQuestionService.java
+++ b/src/main/java/com/ftm/server/application/service/grooming/question/DeleteGroomingTestQuestionService.java
@@ -1,0 +1,32 @@
+package com.ftm.server.application.service.grooming.question;
+
+import com.ftm.server.application.command.grooming.DeleteGroomingTestQuestionCommand;
+import com.ftm.server.application.port.in.grooming.question.DeleteGroomingTestQuestionUseCase;
+import com.ftm.server.application.port.out.cache.InvalidGroomingTestsWithCachePort;
+import com.ftm.server.application.port.out.persistence.grooming.DeleteGroomingTestAnswerPort;
+import com.ftm.server.application.port.out.persistence.grooming.DeleteGroomingTestQuestionPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteGroomingTestQuestionService implements DeleteGroomingTestQuestionUseCase {
+
+    private final DeleteGroomingTestAnswerPort deleteGroomingTestAnswerPort;
+    private final DeleteGroomingTestQuestionPort deleteGroomingTestQuestionPort;
+    private final InvalidGroomingTestsWithCachePort invalidGroomingTestsWithCachePort;
+
+    @Transactional
+    @Override
+    public void execute(DeleteGroomingTestQuestionCommand command) {
+        // 질문의 답변 목록 삭제
+        deleteGroomingTestAnswerPort.deleteGroomingTestAnswersByQuestionId(command.getId());
+
+        // 질문 삭제
+        deleteGroomingTestQuestionPort.deleteGroomingTestQuestionById(command.getId());
+
+        // 그루밍 테스트 캐싱 목록 초기화
+        invalidGroomingTestsWithCachePort.invalidGroomingTestsCache();
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/grooming/question/SaveGroomingTestQuestionService.java
+++ b/src/main/java/com/ftm/server/application/service/grooming/question/SaveGroomingTestQuestionService.java
@@ -1,0 +1,30 @@
+package com.ftm.server.application.service.grooming.question;
+
+import com.ftm.server.application.command.grooming.SaveGroomingTestQuestionCommand;
+import com.ftm.server.application.port.in.grooming.question.SaveGroomingTestQuestionUseCase;
+import com.ftm.server.application.port.out.cache.InvalidGroomingTestsWithCachePort;
+import com.ftm.server.application.port.out.persistence.grooming.SaveGroomingTestQuestionPort;
+import com.ftm.server.domain.entity.GroomingTestQuestion;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SaveGroomingTestQuestionService implements SaveGroomingTestQuestionUseCase {
+
+    private final SaveGroomingTestQuestionPort saveGroomingTestQuestionPort;
+    private final InvalidGroomingTestsWithCachePort invalidGroomingTestsWithCachePort;
+
+    @Transactional
+    @Override
+    public void execute(SaveGroomingTestQuestionCommand command) {
+        GroomingTestQuestion groomingTestQuestion = GroomingTestQuestion.create(command);
+
+        // 그루밍 테스트 질문 저장
+        saveGroomingTestQuestionPort.saveGroomingTestQuestion(groomingTestQuestion);
+
+        // 그루밍 테스트 캐싱 정보 초기화
+        invalidGroomingTestsWithCachePort.invalidGroomingTestsCache();
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/grooming/question/UpdateGroomingTestQuestionService.java
+++ b/src/main/java/com/ftm/server/application/service/grooming/question/UpdateGroomingTestQuestionService.java
@@ -1,0 +1,43 @@
+package com.ftm.server.application.service.grooming.question;
+
+import com.ftm.server.application.command.grooming.UpdateGroomingTestQuestionCommand;
+import com.ftm.server.application.port.in.grooming.question.UpdateGroomingTestQuestionUseCase;
+import com.ftm.server.application.port.out.cache.InvalidGroomingTestsWithCachePort;
+import com.ftm.server.application.port.out.persistence.grooming.LoadGroomingTestQuestionPort;
+import com.ftm.server.application.port.out.persistence.grooming.UpdateGroomingTestQuestionPort;
+import com.ftm.server.application.query.FindByIdQuery;
+import com.ftm.server.common.exception.CustomException;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.entity.GroomingTestQuestion;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateGroomingTestQuestionService implements UpdateGroomingTestQuestionUseCase {
+
+    private final LoadGroomingTestQuestionPort loadGroomingTestQuestionPort;
+    private final UpdateGroomingTestQuestionPort updateGroomingTestQuestionPort;
+    private final InvalidGroomingTestsWithCachePort invalidGroomingTestsWithCachePort;
+
+    @Transactional
+    @Override
+    public void execute(UpdateGroomingTestQuestionCommand command) {
+        GroomingTestQuestion question =
+                loadGroomingTestQuestionPort
+                        .loadGroomingTestQuestionById(FindByIdQuery.of(command.getId()))
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorResponseCode
+                                                        .GROOMING_TEST_QUESTION_NOT_FOUND));
+
+        // 그루밍 테스트 질문 업데이트
+        question.update(command);
+        updateGroomingTestQuestionPort.updateGroomingTestQuestion(question);
+
+        // 그루밍 테스트 캐시 초기화
+        invalidGroomingTestsWithCachePort.invalidGroomingTestsCache();
+    }
+}

--- a/src/main/java/com/ftm/server/common/response/enums/ErrorResponseCode.java
+++ b/src/main/java/com/ftm/server/common/response/enums/ErrorResponseCode.java
@@ -54,6 +54,8 @@ public enum ErrorResponseCode {
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "E404_008", "요청된 사용자와 게시글에 부합하는 북마크를 찾을 수 없습니다."),
     GROOMING_TEST_QUESTION_NOT_FOUND(
             HttpStatus.NOT_FOUND, "E404_009", "요청한 그루밍 테스트 질문 정보를 찾을 수 없습니다."),
+    GROOMING_TEST_ANSWER_NOT_FOUND(
+            HttpStatus.NOT_FOUND, "E404_010", "요청한 그루밍 테스트 답변 정보를 찾을 수 없습니다."),
 
     // 409번
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "E409_001", "이미 존재하는 사용자입니다."),

--- a/src/main/java/com/ftm/server/common/response/enums/ErrorResponseCode.java
+++ b/src/main/java/com/ftm/server/common/response/enums/ErrorResponseCode.java
@@ -52,6 +52,8 @@ public enum ErrorResponseCode {
     POST_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "E404_006", "요청한 상품을 찾을 수 없습니다."),
     POST_PRODUCT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404_007", "요청한 상품 이미지를 찾을 수 없습니다."),
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "E404_008", "요청된 사용자와 게시글에 부합하는 북마크를 찾을 수 없습니다."),
+    GROOMING_TEST_QUESTION_NOT_FOUND(
+            HttpStatus.NOT_FOUND, "E404_009", "요청한 그루밍 테스트 질문 정보를 찾을 수 없습니다."),
 
     // 409번
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "E409_001", "이미 존재하는 사용자입니다."),

--- a/src/main/java/com/ftm/server/domain/entity/GroomingTestAnswer.java
+++ b/src/main/java/com/ftm/server/domain/entity/GroomingTestAnswer.java
@@ -1,5 +1,7 @@
 package com.ftm.server.domain.entity;
 
+import com.ftm.server.application.command.grooming.answer.SaveGroomingTestAnswerCommand;
+import com.ftm.server.application.command.grooming.answer.UpdateGroomingTestAnswerCommand;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -46,5 +48,19 @@ public class GroomingTestAnswer extends BaseTime {
                 .createdAt(createdAt)
                 .updatedAt(updatedAt)
                 .build();
+    }
+
+    public static GroomingTestAnswer create(SaveGroomingTestAnswerCommand command) {
+        return GroomingTestAnswer.builder()
+                .groomingTestQuestionId(command.getQuestionId())
+                .answer(command.getAnswer())
+                .score(command.getScore())
+                .build();
+    }
+
+    public void update(UpdateGroomingTestAnswerCommand command) {
+        if (command.getQuestionId() != null) this.groomingTestQuestionId = command.getQuestionId();
+        if (command.getAnswer() != null) this.answer = command.getAnswer();
+        if (command.getScore() != null) this.score = command.getScore();
     }
 }

--- a/src/main/java/com/ftm/server/domain/entity/GroomingTestQuestion.java
+++ b/src/main/java/com/ftm/server/domain/entity/GroomingTestQuestion.java
@@ -1,5 +1,7 @@
 package com.ftm.server.domain.entity;
 
+import com.ftm.server.application.command.grooming.SaveGroomingTestQuestionCommand;
+import com.ftm.server.application.command.grooming.UpdateGroomingTestQuestionCommand;
 import com.ftm.server.domain.enums.GroomingCategory;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -42,5 +44,18 @@ public class GroomingTestQuestion extends BaseTime {
                 .createdAt(createdAt)
                 .updatedAt(updatedAt)
                 .build();
+    }
+
+    public static GroomingTestQuestion create(SaveGroomingTestQuestionCommand command) {
+        return GroomingTestQuestion.builder()
+                .groomingCategory(command.getGroomingCategory())
+                .question(command.getQuestion())
+                .build();
+    }
+
+    public void update(UpdateGroomingTestQuestionCommand command) {
+        if (command.getGroomingCategory() != null)
+            this.groomingCategory = command.getGroomingCategory();
+        if (command.getQuestion() != null) this.question = command.getQuestion();
     }
 }

--- a/src/main/java/com/ftm/server/domain/entity/User.java
+++ b/src/main/java/com/ftm/server/domain/entity/User.java
@@ -149,6 +149,15 @@ public class User extends BaseTime {
                 .build();
     }
 
+    public static User createAdminUser(String email, String password, String nickname) {
+        return User.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .role(UserRole.ADMIN)
+                .build();
+    }
+
     public void updateGroomingInfo(Integer groomingScore, Long groomingLevelId) {
         this.groomingScore = groomingScore;
         this.groomingLevelId = groomingLevelId;

--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -119,7 +119,9 @@ public class SecurityConfig {
 
                             authorize
                                     .requestMatchers("/api/grooming/tests/questions/**")
-                                    .hasRole(UserRole.ADMIN.getValue());
+                                    .hasRole(UserRole.ADMIN.name())
+                                    .requestMatchers("/api/grooming/tests/answers/**")
+                                    .hasRole(UserRole.ADMIN.name());
 
                             // 그 외 모든 요청은 인증 필요
                             authorize.anyRequest().authenticated();

--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.ftm.server.infrastructure.security;
 
 import com.ftm.server.adapter.out.security.UserPrincipalAdapter;
+import com.ftm.server.domain.enums.UserRole;
 import com.ftm.server.infrastructure.security.handler.PermissionDeniedHandler;
 import com.ftm.server.infrastructure.security.handler.UnauthenticatedAccessHandler;
 import java.util.List;
@@ -115,6 +116,10 @@ public class SecurityConfig {
                                     .permitAll()
                                     .requestMatchers(HttpMethod.POST, POST_ANONYMOUS_MATCHERS)
                                     .permitAll();
+
+                            authorize
+                                    .requestMatchers("/api/grooming/tests/questions/**")
+                                    .hasRole(UserRole.ADMIN.getValue());
 
                             // 그 외 모든 요청은 인증 필요
                             authorize.anyRequest().authenticated();

--- a/src/test/java/com/ftm/server/BaseTest.java
+++ b/src/test/java/com/ftm/server/BaseTest.java
@@ -170,4 +170,27 @@ public class BaseTest {
 
         return new SessionAndUser(session, user);
     }
+
+    protected MockHttpSession createAdminUserAndLogin() {
+        String email = "admin@gmail.com";
+        String password = "admin1234!";
+        String nickname = "admintest";
+
+        User admin = User.createAdminUser(email, password, nickname);
+
+        // session 생성
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(
+                        UserPrincipal.of(admin),
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_" + UserRole.ADMIN.name())));
+        context.setAuthentication(auth);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(
+                HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+
+        return session;
+    }
 }

--- a/src/test/java/com/ftm/server/grooming/answer/DeleteGroomingTestAnswerTest.java
+++ b/src/test/java/com/ftm/server/grooming/answer/DeleteGroomingTestAnswerTest.java
@@ -1,0 +1,84 @@
+package com.ftm.server.grooming.answer;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.out.persistence.mapper.GroomingTestAnswerMapper;
+import com.ftm.server.adapter.out.persistence.mapper.GroomingTestQuestionMapper;
+import com.ftm.server.adapter.out.persistence.model.GroomingTestQuestionJpaEntity;
+import com.ftm.server.adapter.out.persistence.repository.GroomingTestAnswerRepository;
+import com.ftm.server.adapter.out.persistence.repository.GroomingTestQuestionRepository;
+import com.ftm.server.application.command.grooming.SaveGroomingTestQuestionCommand;
+import com.ftm.server.application.command.grooming.answer.SaveGroomingTestAnswerCommand;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.entity.GroomingTestAnswer;
+import com.ftm.server.domain.entity.GroomingTestQuestion;
+import com.ftm.server.domain.enums.GroomingCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class DeleteGroomingTestAnswerTest extends BaseTest {
+
+    @Autowired private GroomingTestQuestionRepository groomingTestQuestionRepository;
+    @Autowired private GroomingTestQuestionMapper groomingTestQuestionMapper;
+    @Autowired private GroomingTestAnswerRepository groomingTestAnswerRepository;
+    @Autowired private GroomingTestAnswerMapper groomingTestAnswerMapper;
+
+    private Long savedAnswerId;
+
+    private ResultActions getResultActions(Long answerId, MockHttpSession session)
+            throws Exception {
+        return mockMvc.perform(
+                RestDocumentationRequestBuilders.delete(
+                                "/api/grooming/tests/answers/{answerId}", answerId)
+                        .session(session));
+    }
+
+    @BeforeEach
+    void setUp() {
+        SaveGroomingTestQuestionCommand questionCommand =
+                SaveGroomingTestQuestionCommand.of(GroomingCategory.BEAUTY, "그루밍 테스트 질문");
+        GroomingTestQuestion question = GroomingTestQuestion.create(questionCommand);
+        GroomingTestQuestionJpaEntity questionJpaEntity =
+                groomingTestQuestionRepository.save(
+                        groomingTestQuestionMapper.toJpaEntity(question));
+
+        SaveGroomingTestAnswerCommand answerCommand =
+                SaveGroomingTestAnswerCommand.of(questionJpaEntity.getId(), "그루밍 테스트 답변", 1);
+        GroomingTestAnswer answer = GroomingTestAnswer.create(answerCommand);
+        savedAnswerId =
+                groomingTestAnswerRepository
+                        .save(groomingTestAnswerMapper.toJpaEntity(answer, questionJpaEntity))
+                        .getId();
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_답변_삭제_성공() throws Exception {
+        // when
+        MockHttpSession session = createAdminUserAndLogin();
+        ResultActions resultActions = getResultActions(savedAnswerId, session);
+
+        // then
+        resultActions.andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_답변_삭제_실패() throws Exception {
+        // when
+        MockHttpSession session = createUserAndLogin();
+        ResultActions resultActions = getResultActions(savedAnswerId, session);
+
+        // then
+        resultActions
+                .andExpect(status().is(ErrorResponseCode.NOT_AUTHORIZATION.getHttpStatus().value()))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/ftm/server/grooming/answer/SaveGroomingTestAnswerTest.java
+++ b/src/test/java/com/ftm/server/grooming/answer/SaveGroomingTestAnswerTest.java
@@ -1,0 +1,101 @@
+package com.ftm.server.grooming.answer;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.in.web.grooming.dto.request.SaveGroomingTestAnswerRequest;
+import com.ftm.server.adapter.out.persistence.mapper.GroomingTestQuestionMapper;
+import com.ftm.server.adapter.out.persistence.repository.GroomingTestQuestionRepository;
+import com.ftm.server.application.command.grooming.SaveGroomingTestQuestionCommand;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.entity.GroomingTestQuestion;
+import com.ftm.server.domain.enums.GroomingCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class SaveGroomingTestAnswerTest extends BaseTest {
+
+    @Autowired private GroomingTestQuestionRepository groomingTestQuestionRepository;
+    @Autowired private GroomingTestQuestionMapper groomingTestQuestionMapper;
+
+    private Long savedQuestionId;
+
+    private ResultActions getResultActions(
+            Long questionId, SaveGroomingTestAnswerRequest request, MockHttpSession session)
+            throws Exception {
+        return mockMvc.perform(
+                RestDocumentationRequestBuilders.post(
+                                "/api/grooming/tests/questions/{questionId}/answers", questionId)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .content(mapper.writeValueAsString(request))
+                        .session(session));
+    }
+
+    @BeforeEach
+    void setUp() {
+        SaveGroomingTestQuestionCommand command =
+                SaveGroomingTestQuestionCommand.of(GroomingCategory.BEAUTY, "그루밍 테스트 질문");
+        GroomingTestQuestion question = GroomingTestQuestion.create(command);
+        savedQuestionId =
+                groomingTestQuestionRepository
+                        .save(groomingTestQuestionMapper.toJpaEntity(question))
+                        .getId();
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_답변_저장_성공() throws Exception {
+        // given
+        SaveGroomingTestAnswerRequest request = new SaveGroomingTestAnswerRequest("그루밍 테스트 답변", 1);
+
+        // when
+        MockHttpSession session = createAdminUserAndLogin();
+        ResultActions resultActions = getResultActions(savedQuestionId, request, session);
+
+        // then
+        resultActions.andExpect(status().isCreated()).andDo(print());
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_답변_저장_실패1() throws Exception {
+        // given
+        SaveGroomingTestAnswerRequest request = new SaveGroomingTestAnswerRequest("그루밍 테스트 답변", 1);
+
+        // when
+        MockHttpSession session = createUserAndLogin();
+        ResultActions resultActions = getResultActions(savedQuestionId, request, session);
+
+        // then
+        resultActions
+                .andExpect(status().is(ErrorResponseCode.NOT_AUTHORIZATION.getHttpStatus().value()))
+                .andDo(print());
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_답변_저장_실패2() throws Exception {
+        // given
+        SaveGroomingTestAnswerRequest request = new SaveGroomingTestAnswerRequest("그루밍 테스트 답변", 1);
+
+        // when
+        MockHttpSession session = createAdminUserAndLogin();
+        ResultActions resultActions = getResultActions(10000000L, request, session);
+
+        // then
+        resultActions
+                .andExpect(
+                        status().is(
+                                        ErrorResponseCode.GROOMING_TEST_QUESTION_NOT_FOUND
+                                                .getHttpStatus()
+                                                .value()))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/ftm/server/grooming/answer/UpdateGroomingTestAnswerTest.java
+++ b/src/test/java/com/ftm/server/grooming/answer/UpdateGroomingTestAnswerTest.java
@@ -1,0 +1,139 @@
+package com.ftm.server.grooming.answer;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.in.web.grooming.dto.request.UpdateGroomingTestAnswerRequest;
+import com.ftm.server.adapter.out.persistence.mapper.GroomingTestAnswerMapper;
+import com.ftm.server.adapter.out.persistence.mapper.GroomingTestQuestionMapper;
+import com.ftm.server.adapter.out.persistence.model.GroomingTestQuestionJpaEntity;
+import com.ftm.server.adapter.out.persistence.repository.GroomingTestAnswerRepository;
+import com.ftm.server.adapter.out.persistence.repository.GroomingTestQuestionRepository;
+import com.ftm.server.application.command.grooming.SaveGroomingTestQuestionCommand;
+import com.ftm.server.application.command.grooming.answer.SaveGroomingTestAnswerCommand;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.entity.GroomingTestAnswer;
+import com.ftm.server.domain.entity.GroomingTestQuestion;
+import com.ftm.server.domain.enums.GroomingCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class UpdateGroomingTestAnswerTest extends BaseTest {
+
+    @Autowired private GroomingTestQuestionRepository groomingTestQuestionRepository;
+    @Autowired private GroomingTestQuestionMapper groomingTestQuestionMapper;
+    @Autowired private GroomingTestAnswerRepository groomingTestAnswerRepository;
+    @Autowired private GroomingTestAnswerMapper groomingTestAnswerMapper;
+
+    private Long savedAnswerId;
+
+    private ResultActions getResultActions(
+            Long answerId, UpdateGroomingTestAnswerRequest request, MockHttpSession session)
+            throws Exception {
+        return mockMvc.perform(
+                RestDocumentationRequestBuilders.patch(
+                                "/api/grooming/tests/answers/{answerId}", answerId)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .content(mapper.writeValueAsString(request))
+                        .session(session));
+    }
+
+    @BeforeEach
+    void setUp() {
+        SaveGroomingTestQuestionCommand questionCommand =
+                SaveGroomingTestQuestionCommand.of(GroomingCategory.BEAUTY, "그루밍 테스트 질문");
+        GroomingTestQuestion question = GroomingTestQuestion.create(questionCommand);
+        GroomingTestQuestionJpaEntity questionJpaEntity =
+                groomingTestQuestionRepository.save(
+                        groomingTestQuestionMapper.toJpaEntity(question));
+
+        SaveGroomingTestAnswerCommand answerCommand =
+                SaveGroomingTestAnswerCommand.of(questionJpaEntity.getId(), "그루밍 테스트 답변", 1);
+        GroomingTestAnswer answer = GroomingTestAnswer.create(answerCommand);
+        savedAnswerId =
+                groomingTestAnswerRepository
+                        .save(groomingTestAnswerMapper.toJpaEntity(answer, questionJpaEntity))
+                        .getId();
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_답변_수정_성공() throws Exception {
+        // given
+        UpdateGroomingTestAnswerRequest request =
+                new UpdateGroomingTestAnswerRequest(null, "그루밍 테스트 답변 수정", 10);
+
+        // when
+        MockHttpSession session = createAdminUserAndLogin();
+        ResultActions resultActions = getResultActions(savedAnswerId, request, session);
+
+        // then
+        resultActions.andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_답변_수정_실패1() throws Exception {
+        // given
+        UpdateGroomingTestAnswerRequest request =
+                new UpdateGroomingTestAnswerRequest(null, null, 10);
+
+        // when
+        MockHttpSession session = createUserAndLogin();
+        ResultActions resultActions = getResultActions(savedAnswerId, request, session);
+
+        // then
+        resultActions
+                .andExpect(status().is(ErrorResponseCode.NOT_AUTHORIZATION.getHttpStatus().value()))
+                .andDo(print());
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_답변_수정_실패2() throws Exception {
+        // given
+        UpdateGroomingTestAnswerRequest request =
+                new UpdateGroomingTestAnswerRequest(null, null, 10);
+
+        // when
+        MockHttpSession session = createAdminUserAndLogin();
+        ResultActions resultActions = getResultActions(1000000L, request, session);
+
+        // then
+        resultActions
+                .andExpect(
+                        status().is(
+                                        ErrorResponseCode.GROOMING_TEST_ANSWER_NOT_FOUND
+                                                .getHttpStatus()
+                                                .value()))
+                .andDo(print());
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_답변_수정_실패3() throws Exception {
+        // given
+        UpdateGroomingTestAnswerRequest request =
+                new UpdateGroomingTestAnswerRequest(100000000L, null, 10);
+
+        // when
+        MockHttpSession session = createAdminUserAndLogin();
+        ResultActions resultActions = getResultActions(savedAnswerId, request, session);
+
+        // then
+        resultActions
+                .andExpect(
+                        status().is(
+                                        ErrorResponseCode.GROOMING_TEST_QUESTION_NOT_FOUND
+                                                .getHttpStatus()
+                                                .value()))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/ftm/server/grooming/question/DeleteGroomingTestQuestionTest.java
+++ b/src/test/java/com/ftm/server/grooming/question/DeleteGroomingTestQuestionTest.java
@@ -1,0 +1,70 @@
+package com.ftm.server.grooming.question;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.out.persistence.mapper.GroomingTestQuestionMapper;
+import com.ftm.server.adapter.out.persistence.repository.GroomingTestQuestionRepository;
+import com.ftm.server.application.command.grooming.SaveGroomingTestQuestionCommand;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.entity.GroomingTestQuestion;
+import com.ftm.server.domain.enums.GroomingCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class DeleteGroomingTestQuestionTest extends BaseTest {
+
+    @Autowired private GroomingTestQuestionRepository groomingTestQuestionRepository;
+    @Autowired private GroomingTestQuestionMapper groomingTestQuestionMapper;
+
+    private Long questionId;
+
+    private ResultActions getResultActions(Long questionId, MockHttpSession session)
+            throws Exception {
+        return mockMvc.perform(
+                RestDocumentationRequestBuilders.delete(
+                                "/api/grooming/tests/questions/{questionId}", questionId)
+                        .session(session));
+    }
+
+    @BeforeEach
+    void setUp() {
+        SaveGroomingTestQuestionCommand command =
+                SaveGroomingTestQuestionCommand.of(GroomingCategory.BEAUTY, "그루밍 테스트 질문");
+        GroomingTestQuestion question = GroomingTestQuestion.create(command);
+        questionId =
+                groomingTestQuestionRepository
+                        .save(groomingTestQuestionMapper.toJpaEntity(question))
+                        .getId();
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_질문_삭제_성공() throws Exception {
+        // when
+        MockHttpSession session = createAdminUserAndLogin();
+        ResultActions resultActions = getResultActions(questionId, session);
+
+        // given
+        resultActions.andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_질문_삭제_실패() throws Exception {
+        // when
+        MockHttpSession session = createUserAndLogin();
+        ResultActions resultActions = getResultActions(questionId, session);
+
+        // given
+        resultActions
+                .andExpect(status().is(ErrorResponseCode.NOT_AUTHORIZATION.getHttpStatus().value()))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/ftm/server/grooming/question/SaveGroomingTestQuestionTest.java
+++ b/src/test/java/com/ftm/server/grooming/question/SaveGroomingTestQuestionTest.java
@@ -1,0 +1,60 @@
+package com.ftm.server.grooming.question;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.in.web.grooming.dto.request.SaveGroomingTestQuestionRequest;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.enums.GroomingCategory;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class SaveGroomingTestQuestionTest extends BaseTest {
+
+    private ResultActions getResultActions(
+            SaveGroomingTestQuestionRequest request, MockHttpSession session) throws Exception {
+        return mockMvc.perform(
+                RestDocumentationRequestBuilders.post("/api/grooming/tests/questions")
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .content(mapper.writeValueAsString(request))
+                        .session(session));
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_질문_저장_성공() throws Exception {
+        // given
+        SaveGroomingTestQuestionRequest request =
+                new SaveGroomingTestQuestionRequest(GroomingCategory.BEAUTY, "테스트 질문입니다.");
+
+        // when
+        MockHttpSession session = createAdminUserAndLogin();
+        ResultActions resultActions = getResultActions(request, session);
+
+        // given
+        resultActions.andExpect(status().isCreated()).andDo(print());
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_질문_저장_실패() throws Exception {
+        // given
+        SaveGroomingTestQuestionRequest request =
+                new SaveGroomingTestQuestionRequest(GroomingCategory.BEAUTY, "테스트 질문입니다.");
+
+        // when
+        MockHttpSession session = createUserAndLogin();
+        ResultActions resultActions = getResultActions(request, session);
+
+        // given
+        resultActions
+                .andExpect(status().is(ErrorResponseCode.NOT_AUTHORIZATION.getHttpStatus().value()))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/ftm/server/grooming/question/UpdateGroomingTestQuestionTest.java
+++ b/src/test/java/com/ftm/server/grooming/question/UpdateGroomingTestQuestionTest.java
@@ -1,0 +1,104 @@
+package com.ftm.server.grooming.question;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.in.web.grooming.dto.request.UpdateGroomingTestQuestionRequest;
+import com.ftm.server.adapter.out.persistence.mapper.GroomingTestQuestionMapper;
+import com.ftm.server.adapter.out.persistence.repository.GroomingTestQuestionRepository;
+import com.ftm.server.application.command.grooming.SaveGroomingTestQuestionCommand;
+import com.ftm.server.common.response.enums.ErrorResponseCode;
+import com.ftm.server.domain.entity.GroomingTestQuestion;
+import com.ftm.server.domain.enums.GroomingCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class UpdateGroomingTestQuestionTest extends BaseTest {
+
+    @Autowired private GroomingTestQuestionRepository groomingTestQuestionRepository;
+    @Autowired private GroomingTestQuestionMapper groomingTestQuestionMapper;
+
+    private Long questionId;
+
+    private ResultActions getResultActions(
+            Long questionId, UpdateGroomingTestQuestionRequest request, MockHttpSession session)
+            throws Exception {
+        return mockMvc.perform(
+                RestDocumentationRequestBuilders.patch(
+                                "/api/grooming/tests/questions/{questionId}", questionId)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .content(mapper.writeValueAsString(request))
+                        .session(session));
+    }
+
+    @BeforeEach
+    void setUp() {
+        SaveGroomingTestQuestionCommand command =
+                SaveGroomingTestQuestionCommand.of(GroomingCategory.BEAUTY, "그루밍 테스트 질문");
+        GroomingTestQuestion question = GroomingTestQuestion.create(command);
+        questionId =
+                groomingTestQuestionRepository
+                        .save(groomingTestQuestionMapper.toJpaEntity(question))
+                        .getId();
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_질문_수정_성공() throws Exception {
+        // given
+        UpdateGroomingTestQuestionRequest request =
+                new UpdateGroomingTestQuestionRequest(null, "질문 수정");
+
+        // when
+        MockHttpSession session = createAdminUserAndLogin();
+        ResultActions resultActions = getResultActions(questionId, request, session);
+
+        // given
+        resultActions.andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_질문_수정_실패1() throws Exception {
+        // given
+        UpdateGroomingTestQuestionRequest request =
+                new UpdateGroomingTestQuestionRequest(null, "질문 수정");
+
+        // when
+        MockHttpSession session = createUserAndLogin();
+        ResultActions resultActions = getResultActions(questionId, request, session);
+
+        // given
+        resultActions
+                .andExpect(status().is(ErrorResponseCode.NOT_AUTHORIZATION.getHttpStatus().value()))
+                .andDo(print());
+    }
+
+    @Test
+    @Transactional
+    void 그루밍_테스트_질문_수정_실패2() throws Exception {
+        // given
+        UpdateGroomingTestQuestionRequest request =
+                new UpdateGroomingTestQuestionRequest(null, "질문 수정");
+
+        // when
+        MockHttpSession session = createAdminUserAndLogin();
+        ResultActions resultActions = getResultActions(1000000L, request, session);
+
+        // given
+        resultActions
+                .andExpect(
+                        status().is(
+                                        ErrorResponseCode.GROOMING_TEST_QUESTION_NOT_FOUND
+                                                .getHttpStatus()
+                                                .value()))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #125 

## 📌 작업 내용 및 특이사항

- 그루밍 테스트 관련 데이터의 변경사항이 있을 경우 기존 DB 서버에 직접 접속해서 수정하고 캐싱 최신화를 위해 서버를 재시작해야했던 번거로움을 없애고자 관리자 전용 API로 설계했습니다.
- 관리자 전용 그루밍 테스트 질문, 답변에 대해 생성, 수정, 삭제 요청하는 기능 구현했습니다.
- 관리자만 요청할 수 있도록 스프링 시큐리티의 hasRole(UserRole.ADMIN.name()) 처리해주었습니다. 
- 그루밍 테스트 질문, 답변 데이터에 대해 변경이 있는 경우, 캐싱되어 있는 그루밍 테스트 목록에도 변경사항을 반영 해주어야 하기 때문에 각각 api 요청 시 캐싱되어 있는 그루밍 테스트 목록 데이터를 초기화하도록 구현했습니다. -> 이후 그루밍 테스트 목록 조회 api 요청 시 다시 캐싱됩니다

## 🔍 참고사항

-

## 📚 기타

-