### PR TITLE
feat : 트렌딩 핏더맨 조회 api 추가(#134)

### DIFF
--- a/src/docs/asciidoc/post-api.adoc
+++ b/src/docs/asciidoc/post-api.adoc
@@ -197,7 +197,7 @@ include::{snippetsDir}/deletePost/4/http-response.adoc[]
 
 === **5. 트렌딩 게시글 조회**
 
-트랜딩 게시글 상세 조회 api 입니다.
+트랜딩 게시글 조회 api 입니다.
 
 ==== Request
 include::{snippetsDir}/loadTrendingPosts/1/http-request.adoc[]
@@ -210,4 +210,19 @@ include::{snippetsDir}/loadTrendingPosts/1/response-fields.adoc[]
 
 ---
 
+
+=== **6. 트렌딩 핏더맨 조회**
+
+트랜딩 핏더맨 조회 api 입니다.
+
+==== Request
+include::{snippetsDir}/loadTrendingMan/1/http-request.adoc[]
+
+==== 성공 Response
+include::{snippetsDir}/loadTrendingMan/1/http-response.adoc[]
+
+==== Response Body Fields
+include::{snippetsDir}/loadTrendingMan/1/response-fields.adoc[]
+
+---
 

--- a/src/main/java/com/ftm/server/adapter/in/web/post/controller/GetTrendingManController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/controller/GetTrendingManController.java
@@ -1,0 +1,29 @@
+package com.ftm.server.adapter.in.web.post.controller;
+
+import com.ftm.server.adapter.in.web.post.dto.response.LoadTrendingManResponse;
+import com.ftm.server.application.port.in.post.LoadTrendingManUseCase;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GetTrendingManController {
+
+    private final LoadTrendingManUseCase loadTrendingManUseCase;
+
+    @GetMapping("/api/posts/trend/users")
+    public ResponseEntity<ApiResponse> getTrendingMan() {
+        List<LoadTrendingManResponse> result =
+                loadTrendingManUseCase.execute().stream()
+                        .map(LoadTrendingManResponse::from)
+                        .toList();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessResponseCode.OK, result));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/LoadTrendingManResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/LoadTrendingManResponse.java
@@ -1,0 +1,17 @@
+package com.ftm.server.adapter.in.web.post.dto.response;
+
+import com.ftm.server.application.vo.post.TrendingUserVo;
+import lombok.Data;
+
+@Data
+public class LoadTrendingManResponse {
+    private final Integer ranking;
+    private final Long userId;
+    private final String userName;
+    private final String userImageUrl;
+
+    public static LoadTrendingManResponse from(TrendingUserVo vo) {
+        return new LoadTrendingManResponse(
+                vo.getRank(), vo.getUserId(), vo.getUserName(), vo.getUserImageUrl());
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/out/cache/LoadTrendingManWithCacheAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/cache/LoadTrendingManWithCacheAdapter.java
@@ -1,15 +1,12 @@
 package com.ftm.server.adapter.out.cache;
 
-import static com.ftm.server.common.consts.StaticConsts.TRENDING_POSTS_CACHE_KEY_ALL;
-import static com.ftm.server.common.consts.StaticConsts.TRENDING_POSTS_CACHE_NAME;
-
-import com.ftm.server.application.port.out.cache.LoadTrendingPostsWithCachePort;
-import com.ftm.server.application.port.out.persistence.post.LoadPostImagePort;
+import com.ftm.server.application.port.out.cache.LoadTrendingManWithCachePort;
 import com.ftm.server.application.port.out.persistence.post.LoadPostWithBookmarkCountPort;
-import com.ftm.server.application.query.FindByIdsQuery;
+import com.ftm.server.application.port.out.persistence.user.LoadUserImagePort;
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
-import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
-import com.ftm.server.application.vo.post.TrendingPostVo;
+import com.ftm.server.application.query.FindUserImagesByIdsQuery;
+import com.ftm.server.application.vo.post.TrendingUserVo;
+import com.ftm.server.application.vo.post.UserWithPostCountVo;
 import com.ftm.server.common.annotation.Adapter;
 import java.time.LocalDate;
 import java.util.Comparator;
@@ -20,33 +17,30 @@ import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheConfig;
-import org.springframework.cache.annotation.Cacheable;
 
 @Adapter
-@Slf4j
 @RequiredArgsConstructor
-@CacheConfig(cacheManager = "trendingPostsCacheManager")
-public class LoadTrendingPostsWithCacheAdapter implements LoadTrendingPostsWithCachePort {
+@Slf4j
+@CacheConfig(cacheManager = "trendingUsersCacheManager")
+public class LoadTrendingManWithCacheAdapter implements LoadTrendingManWithCachePort {
 
     private final LoadPostWithBookmarkCountPort loadPostPort;
-    private final LoadPostImagePort loadPostImagePort;
 
-    private static final int N = 15;
+    private final LoadUserImagePort loadUserImagePort;
+
+    private final Integer N = 5;
 
     @Override
-    @Cacheable(value = TRENDING_POSTS_CACHE_NAME, key = TRENDING_POSTS_CACHE_KEY_ALL)
-    public List<TrendingPostVo> loadTrendingPosts() {
+    public List<TrendingUserVo> loadTrendingMan() {
 
         // 현재보다 1주일 이전에 작성된 게시물만 조회(북마크 조회수 포함) (예전 게시물은 포함x)
-        List<PostWithBookmarkCountVo> rawPosts =
-                loadPostPort.loadAllPostsWithBookmarkCount(
+        List<UserWithPostCountVo> userWithCount =
+                loadPostPort.loadAllPostsWithUserAndBookmarkCount(
                         FindPostsByCreatedDateQuery.of(LocalDate.now()));
-
-        if (rawPosts.isEmpty()) return List.of();
 
         // 1. 최대값 계산 (정규화를 위해)
         long maxView = 1, maxLike = 1, maxScrap = 1;
-        for (PostWithBookmarkCountVo post : rawPosts) {
+        for (UserWithPostCountVo post : userWithCount) {
             maxView = Math.max(maxView, post.getViewCount());
             maxLike = Math.max(maxLike, post.getLikeCount());
             maxScrap = Math.max(maxScrap, post.getScrapCount());
@@ -56,8 +50,8 @@ public class LoadTrendingPostsWithCacheAdapter implements LoadTrendingPostsWithC
         long finalMaxView = maxView;
         long finalMaxLike = maxLike;
         long finalMaxScrap = maxScrap;
-        List<PostWithBookmarkCountVo> topN =
-                rawPosts.stream()
+        List<UserWithPostCountVo> topN =
+                userWithCount.stream()
                         .sorted(
                                 Comparator.comparingDouble(
                                         p ->
@@ -70,23 +64,26 @@ public class LoadTrendingPostsWithCacheAdapter implements LoadTrendingPostsWithC
                         .limit(N)
                         .toList();
 
-        // 3. 각 게시물 이미지 조회 (없으면 null)
-        List<Long> postIds = topN.stream().map(PostWithBookmarkCountVo::getPostId).toList();
+        // 3. 각 User 이미지 조회
+        List<Long> userIds = topN.stream().map(UserWithPostCountVo::getUserId).toList();
 
         Map<Long, String> imageMap = new HashMap<>();
-        postIds.forEach(p -> imageMap.put(p, null));
-        loadPostImagePort
-                .loadRepresentativeImagesByPostIds(FindByIdsQuery.from(postIds))
-                .forEach(
-                        postImage -> imageMap.put(postImage.getPostId(), postImage.getObjectKey()));
+        userIds.forEach(p -> imageMap.put(p, null));
+        loadUserImagePort
+                .loadUserImagesByUserIdIn(FindUserImagesByIdsQuery.of(userIds))
+                .forEach(userImage -> imageMap.put(userImage.getId(), userImage.getObjectKey()));
 
         // 4. 결과 조합 (순위 부여)
         return IntStream.range(0, topN.size())
                 .mapToObj(
                         i -> {
-                            PostWithBookmarkCountVo post = topN.get(i);
-                            String imageKey = imageMap.get(post.getPostId());
-                            return TrendingPostVo.from(post, i + 1, imageKey); // rank = i+1
+                            UserWithPostCountVo userWithPostCountVo = topN.get(i);
+                            String imageKey = imageMap.get(userWithPostCountVo.getUserId());
+                            return TrendingUserVo.of(
+                                    i + 1,
+                                    userWithPostCountVo.getUserId(),
+                                    userWithPostCountVo.getUserName(),
+                                    imageKey); // rank = i+1
                         })
                 .toList();
     }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
@@ -6,13 +6,12 @@ import com.ftm.server.adapter.out.persistence.repository.*;
 import com.ftm.server.application.port.out.persistence.post.*;
 import com.ftm.server.application.query.*;
 import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
+import com.ftm.server.application.vo.post.UserWithPostCountVo;
 import com.ftm.server.common.annotation.Adapter;
 import com.ftm.server.common.exception.CustomException;
 import com.ftm.server.common.response.enums.ErrorResponseCode;
 import com.ftm.server.domain.entity.*;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -294,6 +293,12 @@ public class PostDomainPersistenceAdapter
     public List<PostWithBookmarkCountVo> loadAllPostsWithBookmarkCount(
             FindPostsByCreatedDateQuery query) {
         return postRepository.findAllPostsWithBookmarkCount(query);
+    }
+
+    @Override
+    public List<UserWithPostCountVo> loadAllPostsWithUserAndBookmarkCount(
+            FindPostsByCreatedDateQuery query) {
+        return postRepository.findAllPostsWithUserAndBookmarkCount(query);
     }
 
     @Override

--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/user/UserDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/user/UserDomainPersistenceAdapter.java
@@ -240,7 +240,7 @@ public class UserDomainPersistenceAdapter
     @Override
     public List<String> deleteUserImageByUserList(DeleteUserImageByUserIdCommand command) {
         List<String> imageKeyList =
-                userImageRepository.findAllByUserIdList(command.getUserIdList());
+                userImageRepository.findAllImagesByUserIdList(command.getUserIdList());
         userImageRepository.deleteAllByUserIdList(command.getUserIdList());
         return imageKeyList;
     }
@@ -299,5 +299,12 @@ public class UserDomainPersistenceAdapter
         Optional<BookmarkJpaEntity> bookmarkJpaEntity =
                 bookmarkRepository.findByUserIdAndPostId(query.getUserId(), query.getPostId());
         return bookmarkJpaEntity.map(bookmarkMapper::toDomainEntity);
+    }
+
+    @Override
+    public List<UserImage> loadUserImagesByUserIdIn(FindUserImagesByIdsQuery query) {
+        return userImageRepository.findAllByUserIdList(query.getUserIds()).stream()
+                .map(userImageMapper::toDomainEntity)
+                .toList();
     }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostCustomRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostCustomRepository.java
@@ -2,7 +2,9 @@ package com.ftm.server.adapter.out.persistence.repository;
 
 import com.ftm.server.adapter.out.persistence.model.PostJpaEntity;
 import com.ftm.server.application.query.FindPostByDeleteOptionQuery;
+import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.query.FindPostsByPagingQuery;
+import com.querydsl.core.Tuple;
 import java.util.List;
 import org.springframework.data.domain.Slice;
 
@@ -11,4 +13,6 @@ public interface PostCustomRepository {
     List<PostJpaEntity> findAllByDeletedBefore(FindPostByDeleteOptionQuery query);
 
     Slice<PostJpaEntity> findAllByUserIdWithPaging(FindPostsByPagingQuery query);
+
+    List<Tuple> findAllByCreatedDateInOneWeekAndUserGrouping(FindPostsByCreatedDateQuery query);
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostCustomRepositoryImpl.java
@@ -4,8 +4,11 @@ import static com.ftm.server.adapter.out.persistence.model.QPostJpaEntity.postJp
 
 import com.ftm.server.adapter.out.persistence.model.PostJpaEntity;
 import com.ftm.server.application.query.FindPostByDeleteOptionQuery;
+import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.query.FindPostsByPagingQuery;
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,5 +53,20 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         }
 
         return new SliceImpl<>(result, pageable, hasNext);
+    }
+
+    @Override
+    public List<Tuple> findAllByCreatedDateInOneWeekAndUserGrouping(
+            FindPostsByCreatedDateQuery query) {
+
+        LocalDateTime oneWeekAgo =
+                query.getDate().minusWeeks(1).atStartOfDay(); // 현재 기준 1주일 전 게시물만 조회
+
+        return queryFactory
+                .select(postJpaEntity.user, postJpaEntity.id.count())
+                .from(postJpaEntity)
+                .groupBy(postJpaEntity.user)
+                .where(postJpaEntity.createdAt.goe(oneWeekAgo))
+                .fetch();
     }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepository.java
@@ -2,9 +2,13 @@ package com.ftm.server.adapter.out.persistence.repository;
 
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
+import com.ftm.server.application.vo.post.UserWithPostCountVo;
 import java.util.List;
 
 public interface PostWithBookmarkCustomRepository {
 
     List<PostWithBookmarkCountVo> findAllPostsWithBookmarkCount(FindPostsByCreatedDateQuery query);
+
+    List<UserWithPostCountVo> findAllPostsWithUserAndBookmarkCount(
+            FindPostsByCreatedDateQuery query);
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepositoryImpl.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepositoryImpl.java
@@ -5,6 +5,8 @@ import static com.ftm.server.adapter.out.persistence.model.QPostJpaEntity.postJp
 
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
+import com.ftm.server.application.vo.post.UserWithPostCountVo;
+import com.ftm.server.domain.enums.UserRole;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
@@ -22,7 +24,7 @@ public class PostWithBookmarkCustomRepositoryImpl implements PostWithBookmarkCus
     public List<PostWithBookmarkCountVo> findAllPostsWithBookmarkCount(
             FindPostsByCreatedDateQuery query) {
 
-        LocalDateTime twoWeeksAgo =
+        LocalDateTime oneWeekAgo =
                 query.getDate().minusWeeks(1).atStartOfDay(); // 현재 기준 1주일 전 게시물만 조회
 
         return queryFactory
@@ -37,8 +39,46 @@ public class PostWithBookmarkCustomRepositoryImpl implements PostWithBookmarkCus
                 .from(postJpaEntity)
                 .leftJoin(bookmarkJpaEntity)
                 .on(bookmarkJpaEntity.post.eq(postJpaEntity))
-                .where(postJpaEntity.createdAt.goe(twoWeeksAgo))
+                .where(postJpaEntity.createdAt.goe(oneWeekAgo))
+                .where(postJpaEntity.isDeleted.eq(false)) // 삭제 되지 않은 것만 트렌딩 게시물에 포함하기
                 .groupBy(postJpaEntity.id)
+                .fetch();
+    }
+
+    @Override
+    public List<UserWithPostCountVo> findAllPostsWithUserAndBookmarkCount(
+            FindPostsByCreatedDateQuery query) {
+        LocalDateTime oneWeekAgo =
+                query.getDate().minusWeeks(1).atStartOfDay(); // 현재 기준 1주일 전 게시물만 조회
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                UserWithPostCountVo.class,
+                                postJpaEntity.user.id,
+                                postJpaEntity.user.nickname,
+                                postJpaEntity.viewCount.sum(),
+                                postJpaEntity.likeCount.sum(),
+                                bookmarkJpaEntity.id.count()))
+                .from(postJpaEntity)
+                .leftJoin(bookmarkJpaEntity)
+                .on(bookmarkJpaEntity.post.eq(postJpaEntity))
+                .where(
+                        postJpaEntity
+                                .isDeleted
+                                .eq(false)
+                                .and(
+                                        postJpaEntity.createdAt.goe(
+                                                oneWeekAgo))) // 삭제되지 않은 1주일 이내 게시물만 포함.
+                .where(
+                        postJpaEntity
+                                .user
+                                .isDeleted
+                                .eq(false)
+                                .and(
+                                        postJpaEntity.user.role.eq(
+                                                UserRole.USER))) // 삭제되지 않은 일반 유저만 포함
+                .groupBy(postJpaEntity.user.id, postJpaEntity.user.nickname)
                 .fetch();
     }
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/UserImageRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/UserImageRepository.java
@@ -17,5 +17,8 @@ public interface UserImageRepository extends JpaRepository<UserImageJpaEntity, L
     void deleteAllByUserIdList(@Param("userIds") List<Long> userIds);
 
     @Query("SELECT ui.objectKey FROM UserImageJpaEntity ui WHERE ui.user.id in (:userIds)")
-    List<String> findAllByUserIdList(@Param("userIds") List<Long> userIds);
+    List<String> findAllImagesByUserIdList(@Param("userIds") List<Long> userIds);
+
+    @Query("SELECT ui FROM UserImageJpaEntity ui WHERE ui.user.id in (:userIds)")
+    List<UserImageJpaEntity> findAllByUserIdList(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/ftm/server/application/port/in/post/LoadTrendingManUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/post/LoadTrendingManUseCase.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.in.post;
+
+import com.ftm.server.application.vo.post.TrendingUserVo;
+import com.ftm.server.common.annotation.UseCase;
+import java.util.List;
+
+@UseCase
+public interface LoadTrendingManUseCase {
+    List<TrendingUserVo> execute();
+}

--- a/src/main/java/com/ftm/server/application/port/out/cache/LoadTrendingManWithCachePort.java
+++ b/src/main/java/com/ftm/server/application/port/out/cache/LoadTrendingManWithCachePort.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.out.cache;
+
+import com.ftm.server.application.vo.post.TrendingUserVo;
+import com.ftm.server.common.annotation.Port;
+import java.util.List;
+
+@Port
+public interface LoadTrendingManWithCachePort {
+    List<TrendingUserVo> loadTrendingMan();
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostWithBookmarkCountPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostWithBookmarkCountPort.java
@@ -2,8 +2,14 @@ package com.ftm.server.application.port.out.persistence.post;
 
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
+import com.ftm.server.application.vo.post.UserWithPostCountVo;
+import com.ftm.server.common.annotation.Port;
 import java.util.List;
 
+@Port
 public interface LoadPostWithBookmarkCountPort {
     List<PostWithBookmarkCountVo> loadAllPostsWithBookmarkCount(FindPostsByCreatedDateQuery query);
+
+    List<UserWithPostCountVo> loadAllPostsWithUserAndBookmarkCount(
+            FindPostsByCreatedDateQuery query);
 }

--- a/src/main/java/com/ftm/server/application/port/out/persistence/user/LoadUserImagePort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/user/LoadUserImagePort.java
@@ -1,8 +1,12 @@
 package com.ftm.server.application.port.out.persistence.user;
 
 import com.ftm.server.application.query.FindByUserIdQuery;
+import com.ftm.server.application.query.FindUserImagesByIdsQuery;
 import com.ftm.server.domain.entity.UserImage;
+import java.util.List;
 
 public interface LoadUserImagePort {
     UserImage loadUserImageByUserId(FindByUserIdQuery query);
+
+    List<UserImage> loadUserImagesByUserIdIn(FindUserImagesByIdsQuery query);
 }

--- a/src/main/java/com/ftm/server/application/query/FindUserImagesByIdsQuery.java
+++ b/src/main/java/com/ftm/server/application/query/FindUserImagesByIdsQuery.java
@@ -1,0 +1,15 @@
+package com.ftm.server.application.query;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class FindUserImagesByIdsQuery {
+    List<Long> userIds;
+
+    public static FindUserImagesByIdsQuery of(List<Long> userIds) {
+        return new FindUserImagesByIdsQuery(userIds);
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/post/LoadTrendingManService.java
+++ b/src/main/java/com/ftm/server/application/service/post/LoadTrendingManService.java
@@ -1,0 +1,20 @@
+package com.ftm.server.application.service.post;
+
+import com.ftm.server.application.port.in.post.LoadTrendingManUseCase;
+import com.ftm.server.application.port.out.cache.LoadTrendingManWithCachePort;
+import com.ftm.server.application.vo.post.TrendingUserVo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoadTrendingManService implements LoadTrendingManUseCase {
+
+    private final LoadTrendingManWithCachePort loadTrendingManWithCachePort;
+
+    @Override
+    public List<TrendingUserVo> execute() {
+        return loadTrendingManWithCachePort.loadTrendingMan();
+    }
+}

--- a/src/main/java/com/ftm/server/application/vo/post/TrendingUserVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/TrendingUserVo.java
@@ -1,0 +1,18 @@
+package com.ftm.server.application.vo.post;
+
+import com.ftm.server.common.consts.PropertiesHolder;
+import lombok.Data;
+
+@Data
+public class TrendingUserVo {
+    private final Integer rank;
+    private final Long userId;
+    private final String userName;
+    private final String userImageUrl;
+
+    public static TrendingUserVo of(
+            Integer rank, Long userId, String userName, String userImageUrl) {
+        return new TrendingUserVo(
+                rank, userId, userName, PropertiesHolder.CDN_PATH + "/" + userImageUrl);
+    }
+}

--- a/src/main/java/com/ftm/server/application/vo/post/UserWithPostCountVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/UserWithPostCountVo.java
@@ -1,0 +1,19 @@
+package com.ftm.server.application.vo.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UserWithPostCountVo {
+    private final Long userId;
+    private final String userName;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Long scrapCount;
+
+    public static UserWithPostCountVo of(
+            Long userId, String userName, Integer viewCount, Integer likeCount, Long scrapCount) {
+        return new UserWithPostCountVo(userId, userName, viewCount, likeCount, scrapCount);
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/cache/CaffeineCacheConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/cache/CaffeineCacheConfig.java
@@ -33,4 +33,16 @@ public class CaffeineCacheConfig {
                         .recordStats());
         return manager;
     }
+
+    @Bean("trendingUsersCacheManager") // 트렌딩 게시물 전용 캐시 매지너 TTL 설정 달리함 : 5분에 한번씩 캐시 무효화.
+    public CaffeineCacheManager cacheManagerForTrendingUsers() {
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+        manager.setAllowNullValues(false); // null 값 저장하지 않음
+        manager.setCaffeine(
+                Caffeine.newBuilder()
+                        .expireAfterWrite(5, TimeUnit.MINUTES)
+                        .maximumSize(10)
+                        .recordStats());
+        return manager;
+    }
 }

--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
         "/api/users/options",
         "/api/grooming/tests",
         "/api/auth/session/validity",
-        "/api/posts/*"
+        "/api/posts/**"
     };
 
     private static final String[] POST_ANONYMOUS_MATCHERS = {

--- a/src/test/java/com/ftm/server/post/LoadTrendingManTest.java
+++ b/src/test/java/com/ftm/server/post/LoadTrendingManTest.java
@@ -6,7 +6,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -32,7 +31,7 @@ import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-public class LoadTrendingPostsTes extends BaseTest {
+public class LoadTrendingManTest extends BaseTest {
 
     @Autowired private SavePostPort savePostPort;
 
@@ -41,30 +40,30 @@ public class LoadTrendingPostsTes extends BaseTest {
                     fieldWithPath("status").type(NUMBER).description("응답 상태"),
                     fieldWithPath("code").type(STRING).description("상태 코드"),
                     fieldWithPath("message").type(STRING).description("메시지"),
-                    fieldWithPath("data").type(ARRAY).optional().description("응답 데이터"),
+                    fieldWithPath("data")
+                            .type(ARRAY)
+                            .optional()
+                            .description("응답 데이터 : 대상 사용자가 없는 경우 빈 배열"),
                     fieldWithPath("data[].ranking").type(NUMBER).description("순위"),
-                    fieldWithPath("data[].postId").type(NUMBER).description("게시글 ID"),
-                    fieldWithPath("data[].title").type(STRING).description("게시글 제목"),
-                    fieldWithPath("data[].viewCount").type(NUMBER).description("조회수"),
-                    fieldWithPath("data[].likeCount").type(NUMBER).description("좋아요 수"),
-                    fieldWithPath("data[].scrapCount").type(NUMBER).description("스크랩 수"),
-                    fieldWithPath("data[].imageUrl").type(STRING).description("이미지 url"));
+                    fieldWithPath("data[].userId").type(NUMBER).description("게시글 ID"),
+                    fieldWithPath("data[].userName").type(STRING).description("게시글 제목"),
+                    fieldWithPath("data[].userImageUrl").type(STRING).description("이미지 url"));
 
     private ResultActions getResultActions() throws Exception {
-        return mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts/trend"));
+        return mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts/trend/users"));
     }
 
     private RestDocumentationResultHandler getDocument(Integer identifier) {
         return document(
-                "loadTrendingPosts/" + identifier,
+                "loadTrendingMan/" + identifier,
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint(), getModifiedHeader()),
                 responseFields(responseFields),
                 resource(
                         ResourceSnippetParameters.builder()
                                 .tag("유저픽 게시글")
-                                .summary("트렌딩 게시글 조회 api")
-                                .description("트레딩 게시 조회 api 입니다.")
+                                .summary("트렌딩 핏더맨 조회 api")
+                                .description("트레딩 핏더맨 조회 api 입니다.")
                                 .responseFields(responseFields)
                                 .build()));
     }
@@ -75,15 +74,16 @@ public class LoadTrendingPostsTes extends BaseTest {
     public void test1() throws Exception {
         // given
 
-        SessionAndUser sessionAndUser = createUserAndLoginAndReturnUser(); // 로그인 처리
+        BaseTest.SessionAndUser sessionAndUser = createUserAndLoginAndReturnUser(); // 로그인 처리
 
-        User user = sessionAndUser.user();
+        User user1 = createUserAndLoginAndReturnUser("test1@gmail.com", "gqe123@").user();
+        User user2 = createUserAndLoginAndReturnUser("test2@gmail.com", "gqe123@").user();
 
         // test 용 post 생성
         savePostPort.savePost(
                 Post.create(
                         SavePostCommand.from(
-                                user.getId(),
+                                user1.getId(),
                                 new SavePostRequest(
                                         "test1",
                                         GroomingCategory.FASHION,
@@ -96,7 +96,7 @@ public class LoadTrendingPostsTes extends BaseTest {
         savePostPort.savePost(
                 Post.create(
                         SavePostCommand.from(
-                                user.getId(),
+                                user2.getId(),
                                 new SavePostRequest(
                                         "test2",
                                         GroomingCategory.FASHION,

--- a/src/test/java/com/ftm/server/post/LoadTrendingPostsTest.java
+++ b/src/test/java/com/ftm/server/post/LoadTrendingPostsTest.java
@@ -1,0 +1,123 @@
+package com.ftm.server.post;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.in.web.post.dto.request.SavePostRequest;
+import com.ftm.server.application.command.post.SavePostCommand;
+import com.ftm.server.application.port.out.persistence.post.SavePostPort;
+import com.ftm.server.domain.entity.Post;
+import com.ftm.server.domain.entity.User;
+import com.ftm.server.domain.enums.GroomingCategory;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class LoadTrendingPostsTest extends BaseTest {
+
+    @Autowired private SavePostPort savePostPort;
+
+    private final List<FieldDescriptor> responseFields =
+            List.of(
+                    fieldWithPath("status").type(NUMBER).description("응답 상태"),
+                    fieldWithPath("code").type(STRING).description("상태 코드"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data")
+                            .type(ARRAY)
+                            .optional()
+                            .description("응답 데이터 : 대상 게시물이 없는 경우 빈 배열"),
+                    fieldWithPath("data[].ranking").type(NUMBER).description("순위"),
+                    fieldWithPath("data[].postId").type(NUMBER).description("게시글 ID"),
+                    fieldWithPath("data[].title").type(STRING).description("게시글 제목"),
+                    fieldWithPath("data[].viewCount").type(NUMBER).description("조회수"),
+                    fieldWithPath("data[].likeCount").type(NUMBER).description("좋아요 수"),
+                    fieldWithPath("data[].scrapCount").type(NUMBER).description("스크랩 수"),
+                    fieldWithPath("data[].imageUrl").type(STRING).description("이미지 url"));
+
+    private ResultActions getResultActions() throws Exception {
+        return mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts/trend"));
+    }
+
+    private RestDocumentationResultHandler getDocument(Integer identifier) {
+        return document(
+                "loadTrendingPosts/" + identifier,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint(), getModifiedHeader()),
+                responseFields(responseFields),
+                resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("유저픽 게시글")
+                                .summary("트렌딩 게시글 조회 api")
+                                .description("트레딩 게시 조회 api 입니다.")
+                                .responseFields(responseFields)
+                                .build()));
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("테스트 성공")
+    public void test1() throws Exception {
+        // given
+
+        SessionAndUser sessionAndUser = createUserAndLoginAndReturnUser(); // 로그인 처리
+
+        User user = sessionAndUser.user();
+
+        // test 용 post 생성
+        savePostPort.savePost(
+                Post.create(
+                        SavePostCommand.from(
+                                user.getId(),
+                                new SavePostRequest(
+                                        "test1",
+                                        GroomingCategory.FASHION,
+                                        new ArrayList<>(),
+                                        "content1",
+                                        new ArrayList<>()),
+                                new ArrayList<>(),
+                                new ArrayList<>())));
+
+        savePostPort.savePost(
+                Post.create(
+                        SavePostCommand.from(
+                                user.getId(),
+                                new SavePostRequest(
+                                        "test2",
+                                        GroomingCategory.FASHION,
+                                        new ArrayList<>(),
+                                        "content2",
+                                        new ArrayList<>()),
+                                new ArrayList<>(),
+                                new ArrayList<>())));
+
+        // when
+        ResultActions resultActions = getResultActions();
+
+        // then
+        resultActions
+                .andExpect(status().is(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.data", hasSize(2)));
+
+        // documentation
+        resultActions.andDo(getDocument(1));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #134

## 📌 작업 내용 및 특이사항

- 트렌딩 핏더맨 조회 api 추가했습니다.
- 각 user가 작성한 게시글의 좋아요, 조회수, 스크랩 수 정규화 하여 순서대로 순위 매겼습니다.
- 삭제되지 않은 Role(USER)인 사용자의, 1주일 이내로 작성된 게시글만 대상으로 삼았습니다.
- 트렌딩 게시글 조회 로직과 마찬가지로 추후에 리팩토링이 있을 예정입니다.

## 🔍 참고사항

-

## 📚 기타

-