### PR TITLE
fix: 배포앱의 HTTPS 요청에서 세션 쿠키가 저장되지 않는 버그 해결 작업(#143)

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -24,5 +24,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/src/main/java/com/ftm/server/infrastructure/session/CookieSerializerConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/session/CookieSerializerConfig.java
@@ -1,0 +1,14 @@
+package com.ftm.server.infrastructure.session;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.web.http.CookieSerializer;
+
+@Configuration
+public class CookieSerializerConfig {
+
+    @Bean
+    public CookieSerializer cookieSerializer() {
+        return new ProtocolAwareCookieSerializer();
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/session/ProtocolAwareCookieSerializer.java
+++ b/src/main/java/com/ftm/server/infrastructure/session/ProtocolAwareCookieSerializer.java
@@ -1,0 +1,22 @@
+package com.ftm.server.infrastructure.session;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.session.web.http.DefaultCookieSerializer;
+
+public class ProtocolAwareCookieSerializer extends DefaultCookieSerializer {
+
+    @Override
+    public void writeCookieValue(CookieValue cookieValue) {
+        HttpServletRequest request = cookieValue.getRequest();
+        String proto = request.getHeader("X-Forwarded-Proto");
+
+        boolean isHttps = request.isSecure() || "https".equalsIgnoreCase(proto);
+
+        // HTTPS -> Secure O + SameSite=None
+        // HTTP -> Secure X + SameSite null
+        setUseSecureCookie(isHttps);
+        setSameSite(isHttps ? "None" : null);
+
+        super.writeCookieValue(cookieValue);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,3 +6,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+
+server:
+  forward-headers-strategy: native


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #143 

## 📌 작업 내용 및 특이사항

- 요청 프로토콜(`HTTP`/`HTTPS`)에 따라 세션 쿠키의 `Secure` 및 `SameSite` 설정을 동적으로 처리하도록 `CookieSerializerConfig`, `ProtocolAwareCookieSerializer` 클래스 추가
: `HTTPS` -> Secure + SameSite=None 설정
: `HTTP` -> Secure & SameSite X

- `Spring`이 프록시 환경에서 `HTTPS` 요청을 인식할 수 있도록, `nginx`에 `X-Forwarded-Proto` 헤더를 추가하고, 테스트 및 로컬 환경에서는 프록시를 사용하지 않아서 `application-dev.yml`에 `server.forward-headers-strategy: native` 설정 적용

## 🔍 참고사항
- `HTTPS` 환경에서 브라우저가 `Secure` + `SameSite=None` 속성이 없는 세션 쿠키를 저장하지 않는 이슈 해결 목적
```
로그인 이후 쿠키 내려주실 때 요청으로 온 Origin 또는 http, https 여부에 따라 세션 쿠키를 다르게 내려주실 수 있으실까요?

현재 문제점은

로컬 개발:
HTTP 환경에서 Secure 속성이 있으면 쿠키 저장 안 됨 → 이 부분은 내부적으로 rewrite를 통해(동일 도메인)서 해결이 됨

배포 환경:
HTTPS 환경에서 Secure 속성이 없으면 쿠키 저장 안 됨 → rewrite를 하여도 https환경이라 저장 되지않음

위 문제점으로 인해 배포앱에서 쿠키 세션 저장이 되지 않고 있었네요

원하는 동작은 

로컬 개발 환경 (http인 경우)
쿠키 설정: Set-Cookie: SESSION=session-id; Path=/; HttpOnly (현행유지)

배포 환경(https인 경우)
쿠키 설정: Set-Cookie: SESSION=session-id; Path=/; HttpOnly; Secure; SameSite=None

정리하면 

요청의 Origin 또는 프로토콜(http/https)에 따라 위와 같이 세션쿠키 를 분기해서 내려주실 수 있는지 문의드립니다!

``` 

- `Nginx` → `Spring`으로 전달되는 요청이 HTTP로 인식되는 문제를 방지하기 위한 설정 포함

## 📚 기타

-