### PR TITLE
refactor: 게시글 해시태그 목록 조회 시 비어있는 하위 해시태그도 조회되도록 개선(#145)

### DIFF
--- a/src/main/java/com/ftm/server/application/service/post/LoadPostHashTagsService.java
+++ b/src/main/java/com/ftm/server/application/service/post/LoadPostHashTagsService.java
@@ -21,15 +21,17 @@ public class LoadPostHashTagsService implements LoadPostHashTagsUseCase {
                 Arrays.stream(PostHashtag.values())
                         .collect(Collectors.groupingBy(PostHashtag::getCategory));
 
-        return hashtagGroup.entrySet().stream()
+        return Arrays.stream(HashtagCategory.values())
                 .map(
-                        entry -> {
-                            HashtagCategoryDetailVo category =
-                                    HashtagCategoryDetailVo.of(entry.getKey());
-                            List<PostHashTagVo> hashtags =
-                                    entry.getValue().stream().map(PostHashTagVo::of).toList();
+                        category -> {
+                            HashtagCategoryDetailVo categoryDetailVo =
+                                    HashtagCategoryDetailVo.of(category);
+                            List<PostHashTagVo> hashTagVos =
+                                    hashtagGroup.getOrDefault(category, List.of()).stream()
+                                            .map(PostHashTagVo::of)
+                                            .toList();
 
-                            return PostHashTagDetailVo.of(category, hashtags);
+                            return PostHashTagDetailVo.of(categoryDetailVo, hashTagVos);
                         })
                 .toList();
     }


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #145 

## 📌 작업 내용 및 특이사항

- 게시글 해시태그 목록을 조회할 때, 기존에는 만약 `PERPUME` 이라는 카테고리에 하위 게시글 해시태그 목록이 존재하지 않으면 응답되지 않는 문제를 개선했습니다
- 하위 게시글 해시태그가 존재하지 않는 경우 빈 리스트 값으로 응답되도록 개선했습니다

## 🔍 참고사항

-

## 📚 기타

-