### PR TITLE
feat:그루밍 라운지 - "그루밍 바이블" 목록 조회 api 구현(#153)

### DIFF
--- a/src/docs/asciidoc/post-api.adoc
+++ b/src/docs/asciidoc/post-api.adoc
@@ -277,3 +277,17 @@ include::{snippetsDir}/loadUserPickPopular/1/http-response.adoc[]
 include::{snippetsDir}/loadUserPickPopular/1/response-fields.adoc[]
 
 ---
+
+
+=== **10. 그루밍 라운지 - "그루밍 바이블" 조회**
+
+==== Request
+include::{snippetsDir}/loadUserPickBible/1/http-request.adoc[]
+
+==== 성공 Response
+include::{snippetsDir}/loadUserPickBible/1/http-response.adoc[]
+
+==== Response Body Fields
+include::{snippetsDir}/loadUserPickBible/1/response-fields.adoc[]
+
+---

--- a/src/main/java/com/ftm/server/adapter/in/web/post/controller/GetUserPickPopularPostsController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/controller/GetUserPickPopularPostsController.java
@@ -1,7 +1,7 @@
 package com.ftm.server.adapter.in.web.post.controller;
 
 import com.ftm.server.adapter.in.web.post.dto.response.GetUserPickPopularPostsResponse;
-import com.ftm.server.application.port.in.user.GetUserPickPopularPostsUseCase;
+import com.ftm.server.application.port.in.post.GetUserPickPopularPostsUseCase;
 import com.ftm.server.common.response.ApiResponse;
 import com.ftm.server.common.response.enums.SuccessResponseCode;
 import java.util.List;

--- a/src/main/java/com/ftm/server/adapter/in/web/post/controller/LoadUserPickBiblePostsController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/controller/LoadUserPickBiblePostsController.java
@@ -1,0 +1,27 @@
+package com.ftm.server.adapter.in.web.post.controller;
+
+import com.ftm.server.adapter.in.web.post.dto.response.LoadUserPickBiblePostsResponse;
+import com.ftm.server.application.port.in.post.LoadUserPickBiblePostsUseCase;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+public class LoadUserPickBiblePostsController {
+
+    private final LoadUserPickBiblePostsUseCase userPickBiblePostsUseCase;
+
+    @GetMapping("/api/posts/userpick/bible")
+    public ResponseEntity<ApiResponse> loadUserPickGroomingBiblePosts() {
+        List<LoadUserPickBiblePostsResponse> result =
+                userPickBiblePostsUseCase.execute().stream()
+                        .map(LoadUserPickBiblePostsResponse::from)
+                        .toList();
+        return ResponseEntity.ok(ApiResponse.success(SuccessResponseCode.OK, result));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/LoadUserPickBiblePostsResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/LoadUserPickBiblePostsResponse.java
@@ -1,0 +1,35 @@
+package com.ftm.server.adapter.in.web.post.dto.response;
+
+import com.ftm.server.application.vo.post.UserPickBiblePostsVo;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoadUserPickBiblePostsResponse {
+    private final Integer ranking;
+    private final Long postId;
+    private final String title;
+    private final Long authorId;
+    private final String authorName;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Long scrapCount;
+    private final String imageUrl;
+    private final List<String> hashtags;
+
+    public static LoadUserPickBiblePostsResponse from(UserPickBiblePostsVo vo) {
+        return new LoadUserPickBiblePostsResponse(
+                vo.getRanking(),
+                vo.getPostId(),
+                vo.getTitle(),
+                vo.getAuthorId(),
+                vo.getAuthorName(),
+                vo.getViewCount(),
+                vo.getLikeCount(),
+                vo.getScrapCount(),
+                vo.getImageUrl(),
+                vo.getHashtags());
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/out/cache/LoadUserPickBiblePostsWithCacheAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/cache/LoadUserPickBiblePostsWithCacheAdapter.java
@@ -1,0 +1,45 @@
+package com.ftm.server.adapter.out.cache;
+
+import static com.ftm.server.common.consts.StaticConsts.*;
+
+import com.ftm.server.application.port.out.cache.LoadUserPickBiblePostsWithCachePort;
+import com.ftm.server.application.port.out.persistence.post.LoadPostPort;
+import com.ftm.server.application.query.FindUserPickBiblePostsQuery;
+import com.ftm.server.application.vo.post.PostWithIdAndAuthorVo;
+import com.ftm.server.common.annotation.Adapter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+
+@Adapter
+@RequiredArgsConstructor
+public class LoadUserPickBiblePostsWithCacheAdapter implements LoadUserPickBiblePostsWithCachePort {
+
+    private final LoadPostPort loadPostPort;
+
+    @Override
+    @Cacheable(
+            cacheNames = USER_PICK_BIBLE_POSTS_CACHE_NAME,
+            key = USER_PICK_BIBLE_POSTS_CACHE_KEY_ALL)
+    public List<PostWithIdAndAuthorVo> getUserPickBiblePost() {
+        return execute();
+    }
+
+    @Override
+    @CachePut(cacheNames = USER_PICK_BIBLE_POSTS_CACHE_NAME, key = USER_PICK_BIBLE_POSTS_CACHE_NAME)
+    public List<PostWithIdAndAuthorVo> getUserPickBiblePostCachePut() {
+        return execute();
+    }
+
+    public List<PostWithIdAndAuthorVo> execute() {
+        // 최근 1개월 상위 4개 post id를 조회
+
+        List<PostWithIdAndAuthorVo> postList =
+                loadPostPort.loadUserPickBiblePosts(FindUserPickBiblePostsQuery.of(4));
+
+        if (postList.isEmpty()) return List.of();
+
+        return postList;
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
@@ -5,10 +5,7 @@ import com.ftm.server.adapter.out.persistence.model.*;
 import com.ftm.server.adapter.out.persistence.repository.*;
 import com.ftm.server.application.port.out.persistence.post.*;
 import com.ftm.server.application.query.*;
-import com.ftm.server.application.vo.post.PostAndBookmarkCountVo;
-import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
-import com.ftm.server.application.vo.post.UserIdAndNameVo;
-import com.ftm.server.application.vo.post.UserWithPostCountVo;
+import com.ftm.server.application.vo.post.*;
 import com.ftm.server.common.annotation.Adapter;
 import com.ftm.server.common.exception.CustomException;
 import com.ftm.server.common.response.enums.ErrorResponseCode;
@@ -158,6 +155,17 @@ public class PostDomainPersistenceAdapter
                 .stream()
                 .map(postMapper::toDomainEntity)
                 .toList();
+    }
+
+    @Override
+    public List<PostWithIdAndAuthorVo> loadUserPickBiblePosts(FindUserPickBiblePostsQuery query) {
+        return postRepository.findTopNPostsByLikeCount(query.getLimit());
+    }
+
+    @Override
+    public List<PostWithUserAndBookmarkCountVo> loadPostWithUserAndBookmarkCount(
+            FindByIdsQuery query) {
+        return postRepository.findAllPostsWithUserAndBookmarkCount(query);
     }
 
     @Override

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.ftm.server.adapter.out.persistence.repository;
 
 import com.ftm.server.adapter.out.persistence.model.PostJpaEntity;
 import com.ftm.server.application.vo.post.PostAndBookmarkCountVo;
+import com.ftm.server.application.vo.post.PostWithIdAndAuthorVo;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -40,6 +41,10 @@ public interface PostRepository
             nativeQuery = true)
     List<PostJpaEntity> findTopNPostsByViewCountAndLikeCount(
             @Param("since") LocalDateTime since, @Param("limit") int limit);
+
+    @Query(
+            "select new com.ftm.server.application.vo.post.PostWithIdAndAuthorVo(p.id) from PostJpaEntity p order by p.likeCount DESC")
+    List<PostWithIdAndAuthorVo> findTopNPostsByLikeCount(@Param("limit") int limit);
 
     @Query(
             """

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepository.java
@@ -1,7 +1,9 @@
 package com.ftm.server.adapter.out.persistence.repository;
 
+import com.ftm.server.application.query.FindByIdsQuery;
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
+import com.ftm.server.application.vo.post.PostWithUserAndBookmarkCountVo;
 import com.ftm.server.application.vo.post.UserWithPostCountVo;
 import java.util.List;
 
@@ -11,4 +13,6 @@ public interface PostWithBookmarkCustomRepository {
 
     List<UserWithPostCountVo> findAllPostsWithUserAndBookmarkCount(
             FindPostsByCreatedDateQuery query);
+
+    List<PostWithUserAndBookmarkCountVo> findAllPostsWithUserAndBookmarkCount(FindByIdsQuery query);
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepositoryImpl.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepositoryImpl.java
@@ -3,8 +3,10 @@ package com.ftm.server.adapter.out.persistence.repository;
 import static com.ftm.server.adapter.out.persistence.model.QBookmarkJpaEntity.bookmarkJpaEntity;
 import static com.ftm.server.adapter.out.persistence.model.QPostJpaEntity.postJpaEntity;
 
+import com.ftm.server.application.query.FindByIdsQuery;
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
+import com.ftm.server.application.vo.post.PostWithUserAndBookmarkCountVo;
 import com.ftm.server.application.vo.post.UserWithPostCountVo;
 import com.ftm.server.domain.enums.UserRole;
 import com.querydsl.core.types.Projections;
@@ -79,6 +81,38 @@ public class PostWithBookmarkCustomRepositoryImpl implements PostWithBookmarkCus
                                         postJpaEntity.user.role.eq(
                                                 UserRole.USER))) // 삭제되지 않은 일반 유저만 포함
                 .groupBy(postJpaEntity.user.id, postJpaEntity.user.nickname)
+                .fetch();
+    }
+
+    @Override
+    public List<PostWithUserAndBookmarkCountVo> findAllPostsWithUserAndBookmarkCount(
+            FindByIdsQuery query) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                PostWithUserAndBookmarkCountVo.class,
+                                postJpaEntity.id,
+                                postJpaEntity.user.id,
+                                postJpaEntity.user.nickname,
+                                postJpaEntity.title,
+                                postJpaEntity.content,
+                                postJpaEntity.hashtags,
+                                postJpaEntity.viewCount, // sum() 쓰지 마세요
+                                postJpaEntity.likeCount, // sum() 쓰지 마세요
+                                bookmarkJpaEntity.id.countDistinct() // 북마크 개수
+                                ))
+                .from(postJpaEntity)
+                .leftJoin(bookmarkJpaEntity)
+                .on(bookmarkJpaEntity.post.eq(postJpaEntity))
+                .groupBy(
+                        postJpaEntity.id,
+                        postJpaEntity.user.id,
+                        postJpaEntity.user.nickname,
+                        postJpaEntity.title,
+                        postJpaEntity.content,
+                        postJpaEntity.hashtags,
+                        postJpaEntity.viewCount,
+                        postJpaEntity.likeCount)
                 .fetch();
     }
 }

--- a/src/main/java/com/ftm/server/adapter/out/scheduler/GetUserPickBiblePostsScheduler.java
+++ b/src/main/java/com/ftm/server/adapter/out/scheduler/GetUserPickBiblePostsScheduler.java
@@ -1,0 +1,27 @@
+package com.ftm.server.adapter.out.scheduler;
+
+import com.ftm.server.application.port.out.cache.LoadUserPickBiblePostsWithCachePort;
+import com.ftm.server.common.annotation.Adapter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@Adapter
+@RequiredArgsConstructor
+public class GetUserPickBiblePostsScheduler {
+
+    private final LoadUserPickBiblePostsWithCachePort loadUserPickBiblePostsWithCachePort;
+
+    // 마지막 실행으로부터 57분 뒤에 재실행됨.
+    // cache TTL 값인 1시간이 끝나기 이전에 캐시를 업데이트 해 놓는다.
+    @Scheduled(fixedRateString = "PT57M", initialDelayString = "PT1M")
+    public void run() {
+        log.info(
+                "Loading UserPick Bible Posts at {}",
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        loadUserPickBiblePostsWithCachePort.getUserPickBiblePostCachePut();
+    }
+}

--- a/src/main/java/com/ftm/server/application/port/in/post/GetUserPickPopularPostsUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/post/GetUserPickPopularPostsUseCase.java
@@ -1,4 +1,4 @@
-package com.ftm.server.application.port.in.user;
+package com.ftm.server.application.port.in.post;
 
 import com.ftm.server.application.vo.post.UserPickPopularPostsVo;
 import com.ftm.server.common.annotation.UseCase;

--- a/src/main/java/com/ftm/server/application/port/in/post/LoadUserPickBiblePostsUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/post/LoadUserPickBiblePostsUseCase.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.port.in.post;
+
+import com.ftm.server.application.vo.post.UserPickBiblePostsVo;
+import com.ftm.server.common.annotation.UseCase;
+import java.util.List;
+
+@UseCase
+public interface LoadUserPickBiblePostsUseCase {
+    List<UserPickBiblePostsVo> execute();
+}

--- a/src/main/java/com/ftm/server/application/port/out/cache/LoadUserPickBiblePostsWithCachePort.java
+++ b/src/main/java/com/ftm/server/application/port/out/cache/LoadUserPickBiblePostsWithCachePort.java
@@ -1,0 +1,11 @@
+package com.ftm.server.application.port.out.cache;
+
+import com.ftm.server.application.vo.post.PostWithIdAndAuthorVo;
+import java.util.List;
+
+public interface LoadUserPickBiblePostsWithCachePort {
+
+    List<PostWithIdAndAuthorVo> getUserPickBiblePost();
+
+    List<PostWithIdAndAuthorVo> getUserPickBiblePostCachePut();
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostPort.java
@@ -1,9 +1,7 @@
 package com.ftm.server.application.port.out.persistence.post;
 
-import com.ftm.server.application.query.FindByIdQuery;
-import com.ftm.server.application.query.FindByUserIdsQuery;
-import com.ftm.server.application.query.FindPostByDeleteOptionQuery;
-import com.ftm.server.application.query.FindUserPickPopularPostsQuery;
+import com.ftm.server.application.query.*;
+import com.ftm.server.application.vo.post.PostWithIdAndAuthorVo;
 import com.ftm.server.common.annotation.Port;
 import com.ftm.server.domain.entity.Post;
 import java.util.List;
@@ -19,4 +17,6 @@ public interface LoadPostPort {
     List<Post> loadPostsByDeleteOption(FindPostByDeleteOptionQuery query);
 
     List<Post> loadUserPickPopularPosts(FindUserPickPopularPostsQuery query);
+
+    List<PostWithIdAndAuthorVo> loadUserPickBiblePosts(FindUserPickBiblePostsQuery query);
 }

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostWithBookmarkCountPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostWithBookmarkCountPort.java
@@ -1,9 +1,11 @@
 package com.ftm.server.application.port.out.persistence.post;
 
 import com.ftm.server.application.query.FindBookmarkCountByPostIdsQuery;
+import com.ftm.server.application.query.FindByIdsQuery;
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.vo.post.PostAndBookmarkCountVo;
 import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
+import com.ftm.server.application.vo.post.PostWithUserAndBookmarkCountVo;
 import com.ftm.server.application.vo.post.UserWithPostCountVo;
 import com.ftm.server.common.annotation.Port;
 import java.util.List;
@@ -16,4 +18,6 @@ public interface LoadPostWithBookmarkCountPort {
             FindPostsByCreatedDateQuery query);
 
     List<PostAndBookmarkCountVo> getPostAndBookmarkCount(FindBookmarkCountByPostIdsQuery query);
+
+    List<PostWithUserAndBookmarkCountVo> loadPostWithUserAndBookmarkCount(FindByIdsQuery query);
 }

--- a/src/main/java/com/ftm/server/application/query/FindUserPickBiblePostsQuery.java
+++ b/src/main/java/com/ftm/server/application/query/FindUserPickBiblePostsQuery.java
@@ -1,0 +1,15 @@
+package com.ftm.server.application.query;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindUserPickBiblePostsQuery {
+
+    private final Integer limit;
+
+    public static FindUserPickBiblePostsQuery of(Integer limit) {
+        return new FindUserPickBiblePostsQuery(limit);
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/post/GetUserPickPopularPostsService.java
+++ b/src/main/java/com/ftm/server/application/service/post/GetUserPickPopularPostsService.java
@@ -1,6 +1,6 @@
 package com.ftm.server.application.service.post;
 
-import com.ftm.server.application.port.in.user.GetUserPickPopularPostsUseCase;
+import com.ftm.server.application.port.in.post.GetUserPickPopularPostsUseCase;
 import com.ftm.server.application.port.out.cache.LoadUserPickPopularWithCachePort;
 import com.ftm.server.application.port.out.persistence.post.LoadPostImagePort;
 import com.ftm.server.application.port.out.persistence.post.LoadPostWithBookmarkCountPort;

--- a/src/main/java/com/ftm/server/application/service/post/LoadUserPickBiblePostsService.java
+++ b/src/main/java/com/ftm/server/application/service/post/LoadUserPickBiblePostsService.java
@@ -1,0 +1,82 @@
+package com.ftm.server.application.service.post;
+
+import com.ftm.server.application.port.in.post.LoadUserPickBiblePostsUseCase;
+import com.ftm.server.application.port.out.cache.LoadUserPickBiblePostsWithCachePort;
+import com.ftm.server.application.port.out.persistence.post.LoadPostImagePort;
+import com.ftm.server.application.port.out.persistence.post.LoadPostWithBookmarkCountPort;
+import com.ftm.server.application.query.FindByIdsQuery;
+import com.ftm.server.application.vo.post.*;
+import com.ftm.server.common.consts.PropertiesHolder;
+import com.ftm.server.domain.entity.PostImage;
+import com.ftm.server.domain.enums.PostHashtag;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoadUserPickBiblePostsService implements LoadUserPickBiblePostsUseCase {
+
+    private final LoadUserPickBiblePostsWithCachePort loadUserPickBibleWithCachePort;
+
+    private final LoadPostWithBookmarkCountPort loadPostWithBookmarkCountPort;
+    private final LoadPostImagePort loadPostImagePort;
+
+    @Override
+    public List<UserPickBiblePostsVo> execute() {
+        // 1. 좋아요 누적 순으로 상위 4개의 게시물을 cache 에서 조회
+        List<PostWithIdAndAuthorVo> postList =
+                loadUserPickBibleWithCachePort.getUserPickBiblePost();
+
+        // 2) id 목록
+        List<Long> postIds = postList.stream().map(PostWithIdAndAuthorVo::getPostId).toList();
+
+        // 3) post 상세 조회
+        Map<Long, PostWithUserAndBookmarkCountVo> detailPostMap =
+                loadPostWithBookmarkCountPort
+                        .loadPostWithUserAndBookmarkCount(FindByIdsQuery.from(postIds))
+                        .stream()
+                        .collect(Collectors.toMap(PostWithUserAndBookmarkCountVo::getId, vo -> vo));
+
+        // 4) 대표 이미지
+        List<PostImage> postImages =
+                loadPostImagePort.loadRepresentativeImagesByPostIds(FindByIdsQuery.from(postIds));
+        var imageUrlMap =
+                postImages.stream()
+                        .collect(
+                                java.util.stream.Collectors.toMap(
+                                        PostImage::getPostId,
+                                        PostImage::getObjectKey,
+                                        (a, b) -> a // 중복 시 첫 이미지
+                                        ));
+
+        // 5) 합치기 (postList 순서 = 랭킹)
+        return IntStream.range(0, postIds.size())
+                .mapToObj(
+                        i -> {
+                            Long postId = postIds.get(i);
+                            PostWithUserAndBookmarkCountVo p = detailPostMap.get(postId);
+                            int ranking = i + 1;
+                            String imageUrl =
+                                    imageUrlMap.getOrDefault(
+                                            p.getId(),
+                                            PropertiesHolder.POST_DEFAULT_IMAGE); // 없으면 null
+                            List<String> hashtags =
+                                    p.getHashtags() == null || p.getHashtags().length == 0
+                                            ? List.of()
+                                            : Arrays.stream(p.getHashtags())
+                                                    .map(PostHashtag::getTag)
+                                                    .toList();
+                            return UserPickBiblePostsVo.of(
+                                    ranking,
+                                    p,
+                                    PropertiesHolder.CDN_PATH + "/" + imageUrl,
+                                    hashtags);
+                        })
+                .toList();
+    }
+}

--- a/src/main/java/com/ftm/server/application/vo/post/PostWithIdAndAuthorVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/PostWithIdAndAuthorVo.java
@@ -1,0 +1,10 @@
+package com.ftm.server.application.vo.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostWithIdAndAuthorVo {
+    private final Long postId;
+}

--- a/src/main/java/com/ftm/server/application/vo/post/PostWithUserAndBookmarkCountVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/PostWithUserAndBookmarkCountVo.java
@@ -1,0 +1,19 @@
+package com.ftm.server.application.vo.post;
+
+import com.ftm.server.domain.enums.PostHashtag;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostWithUserAndBookmarkCountVo {
+    private final Long id;
+    private final Long userId;
+    private final String userName;
+    private final String title;
+    private final String content;
+    private final PostHashtag[] hashtags;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Long scrapCount;
+}

--- a/src/main/java/com/ftm/server/application/vo/post/UserPickBiblePostsVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/UserPickBiblePostsVo.java
@@ -1,0 +1,38 @@
+package com.ftm.server.application.vo.post;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserPickBiblePostsVo {
+    private final Integer ranking;
+    private final Long postId;
+    private final String title;
+    private final Long authorId;
+    private final String authorName;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Long scrapCount;
+    private final String imageUrl;
+    private final List<String> hashtags;
+
+    public static UserPickBiblePostsVo of(
+            Integer ranking,
+            PostWithUserAndBookmarkCountVo post,
+            String imageUrl,
+            List<String> hashtags) {
+        return new UserPickBiblePostsVo(
+                ranking,
+                post.getId(),
+                post.getTitle(),
+                post.getUserId(),
+                post.getUserName(),
+                post.getViewCount(),
+                post.getLikeCount(),
+                post.getScrapCount(),
+                imageUrl,
+                hashtags);
+    }
+}

--- a/src/main/java/com/ftm/server/common/consts/StaticConsts.java
+++ b/src/main/java/com/ftm/server/common/consts/StaticConsts.java
@@ -21,4 +21,7 @@ public class StaticConsts {
 
     public static final String USER_PICK_POPULAR_POSTS_CACHE_NAME = "ftm:posts:userpick:popular";
     public static final String USER_PICK_POPULAR_POSTS_CACHE_KEY_ALL = "'all'";
+
+    public static final String USER_PICK_BIBLE_POSTS_CACHE_NAME = "ftm:posts:userpick:bible";
+    public static final String USER_PICK_BIBLE_POSTS_CACHE_KEY_ALL = "'all'";
 }

--- a/src/test/java/com/ftm/server/post/LoadUserPickBiblePostsTest.java
+++ b/src/test/java/com/ftm/server/post/LoadUserPickBiblePostsTest.java
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -31,7 +32,7 @@ import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-public class LoadUserPickPopularPostsTest extends BaseTest {
+public class LoadUserPickBiblePostsTest extends BaseTest {
 
     @Autowired private SavePostPort savePostPort;
 
@@ -58,20 +59,20 @@ public class LoadUserPickPopularPostsTest extends BaseTest {
                             .description("게시글 해시태그 : 한글 태그 표시. 없는 경우 빈 배열([])로 표시"));
 
     private ResultActions getResultActions() throws Exception {
-        return mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts/userpick/popular"));
+        return mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts/userpick/bible"));
     }
 
     private RestDocumentationResultHandler getDocument(Integer identifier) {
         return document(
-                "loadUserPickPopular/" + identifier,
+                "loadUserPickBible/" + identifier,
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint(), getModifiedHeader()),
                 responseFields(responseFields),
                 resource(
                         ResourceSnippetParameters.builder()
                                 .tag("유저픽 게시글")
-                                .summary("\"요즘 인기있는 글\" 목록 조회 api")
-                                .description("그루밍 라운지 내 \"요즘 인기있는 글\" 목록 조회 api 입니다.")
+                                .summary("\"그루밍 바이블\" 목록 조회 api")
+                                .description("그루밍 라운지 내 \"그루밍 바이블\" 목록 조회 api 입니다.")
                                 .responseFields(responseFields)
                                 .build()));
     }
@@ -81,6 +82,7 @@ public class LoadUserPickPopularPostsTest extends BaseTest {
     @DisplayName("테스트 성공")
     public void test1() throws Exception {
         // given
+
         SessionAndUser sessionAndUser = createUserAndLoginAndReturnUser(); // 로그인 처리
 
         User user = sessionAndUser.user();


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #153

## 📌 작업 내용 및 특이사항

- 그루밍 바이블 목록 조회 api 구현
- 누적 좋아요가 많은 순서대로 상위 4개의 게시물을 조회
- "그루밍 라운지 - 인기 게시물" 조회와 마찬가지로 post id만 캐싱해놓고, 조회될 때 마다 상세 정보는 쿼리 조회 방식으로 구현했습니다.

## 🔍 참고사항

- "그루밍 라운지 - 인기 게시물" 목록 조회 api에서 post id만 캐싱을 해 놔야 하는데, 일부 다른 값도 캐싱해 놓는 실수가 있었습니다...
- 추가로 refactor 이슈 올리도록 하겠습니다. 
- "그루밍 라운지 - 인기 게시물" 관련 브랜치를 develop에 merge 후에 restdocs 관련  task가 실패했습니다(그루밍 테스트 결과 저장)
- 이번 브랜치까지 한번 더 올려보고, 또다시 실패하면 이후에 오류 나는 부분을 꼼꼼히 살펴보도록 하겠습니다.

## 📚 기타

-