### PR TITLE
feat:그루밍 라운지 - "다시 찾아보고 싶은 그루밍" 목록 조회 api 구현(#155)

### DIFF
--- a/src/docs/asciidoc/post-api.adoc
+++ b/src/docs/asciidoc/post-api.adoc
@@ -291,3 +291,17 @@ include::{snippetsDir}/loadUserPickBible/1/http-response.adoc[]
 include::{snippetsDir}/loadUserPickBible/1/response-fields.adoc[]
 
 ---
+
+
+=== **11. 그루밍 라운지 - "다시 찾아보고 싶은 그루밍" 조회**
+
+==== Request
+include::{snippetsDir}/loadUserPickTopBookmark/1/http-request.adoc[]
+
+==== 성공 Response
+include::{snippetsDir}/loadUserPickTopBookmark/1/http-response.adoc[]
+
+==== Response Body Fields
+include::{snippetsDir}/loadUserPickTopBookmark/1/response-fields.adoc[]
+
+---

--- a/src/main/java/com/ftm/server/adapter/in/web/post/controller/LoadUserPickTopBookmarkPostsController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/controller/LoadUserPickTopBookmarkPostsController.java
@@ -1,0 +1,25 @@
+package com.ftm.server.adapter.in.web.post.controller;
+
+import com.ftm.server.adapter.in.web.post.dto.response.LoadUserPickTopBookmarkPostsResponse;
+import com.ftm.server.application.port.in.post.LoadUserPickTopBookmarkPostsUseCase;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LoadUserPickTopBookmarkPostsController {
+
+    private final LoadUserPickTopBookmarkPostsUseCase useCase;
+
+    @GetMapping("/api/posts/userpick/top-bookmarks")
+    public ResponseEntity<ApiResponse> loadTopBookmarkPosts() {
+        List<LoadUserPickTopBookmarkPostsResponse> result =
+                useCase.execute().stream().map(LoadUserPickTopBookmarkPostsResponse::from).toList();
+        return ResponseEntity.ok(ApiResponse.success(SuccessResponseCode.OK, result));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/LoadUserPickTopBookmarkPostsResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/LoadUserPickTopBookmarkPostsResponse.java
@@ -1,0 +1,36 @@
+package com.ftm.server.adapter.in.web.post.dto.response;
+
+import com.ftm.server.application.vo.post.LoadUserPickTopBookmarkPostsVo;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoadUserPickTopBookmarkPostsResponse {
+
+    private final Integer ranking;
+    private final Long postId;
+    private final String title;
+    private final Long authorId;
+    private final String authorName;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Long scrapCount;
+    private final String imageUrl;
+    private final List<String> hashtags;
+
+    public static LoadUserPickTopBookmarkPostsResponse from(LoadUserPickTopBookmarkPostsVo vo) {
+        return new LoadUserPickTopBookmarkPostsResponse(
+                vo.getRanking(),
+                vo.getPostId(),
+                vo.getTitle(),
+                vo.getAuthorId(),
+                vo.getAuthorName(),
+                vo.getViewCount(),
+                vo.getLikeCount(),
+                vo.getScrapCount(),
+                vo.getImageUrl(),
+                vo.getHashtags());
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/out/cache/LoadUserPickBiblePostsWithCacheAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/cache/LoadUserPickBiblePostsWithCacheAdapter.java
@@ -27,7 +27,9 @@ public class LoadUserPickBiblePostsWithCacheAdapter implements LoadUserPickBible
     }
 
     @Override
-    @CachePut(cacheNames = USER_PICK_BIBLE_POSTS_CACHE_NAME, key = USER_PICK_BIBLE_POSTS_CACHE_NAME)
+    @CachePut(
+            cacheNames = USER_PICK_BIBLE_POSTS_CACHE_NAME,
+            key = USER_PICK_BIBLE_POSTS_CACHE_KEY_ALL)
     public List<PostWithIdAndAuthorVo> getUserPickBiblePostCachePut() {
         return execute();
     }

--- a/src/main/java/com/ftm/server/adapter/out/cache/LoadUserPickTopBookmarkPostsWithCacheAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/cache/LoadUserPickTopBookmarkPostsWithCacheAdapter.java
@@ -1,0 +1,47 @@
+package com.ftm.server.adapter.out.cache;
+
+import static com.ftm.server.common.consts.StaticConsts.USER_PICK_TOP_BOOKMARK_POSTS_CACHE_KEY_ALL;
+import static com.ftm.server.common.consts.StaticConsts.USER_PICK_TOP_BOOKMARK_POSTS_CACHE_NAME;
+
+import com.ftm.server.application.port.out.cache.LoadUserPickTopBookmarkPostsWithCachePort;
+import com.ftm.server.application.port.out.persistence.post.LoadPostPort;
+import com.ftm.server.application.query.FindTopPostsByBookmarkCountQuery;
+import com.ftm.server.application.vo.post.PostWithIdAndAuthorVo;
+import com.ftm.server.common.annotation.Adapter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+
+@Adapter
+@RequiredArgsConstructor
+@CacheConfig(cacheManager = "userPickTopBookmarkPostsCacheManager")
+public class LoadUserPickTopBookmarkPostsWithCacheAdapter
+        implements LoadUserPickTopBookmarkPostsWithCachePort {
+
+    private final LoadPostPort loadPostPort;
+
+    @Override
+    @Cacheable(
+            cacheNames = USER_PICK_TOP_BOOKMARK_POSTS_CACHE_NAME,
+            key = USER_PICK_TOP_BOOKMARK_POSTS_CACHE_KEY_ALL)
+    public List<PostWithIdAndAuthorVo> getTopBookmarkPosts() {
+        return execute();
+    }
+
+    @Override
+    @CachePut(
+            cacheNames = USER_PICK_TOP_BOOKMARK_POSTS_CACHE_NAME,
+            key = USER_PICK_TOP_BOOKMARK_POSTS_CACHE_KEY_ALL)
+    public List<PostWithIdAndAuthorVo> getTopBookmarkPostsCachePut() {
+        return execute();
+    }
+
+    private List<PostWithIdAndAuthorVo> execute() {
+        List<PostWithIdAndAuthorVo> posts =
+                loadPostPort.loadTopPostsByBookmarkCount(FindTopPostsByBookmarkCountQuery.of(4));
+        if (posts.isEmpty()) return List.of();
+        return posts;
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
@@ -163,6 +163,12 @@ public class PostDomainPersistenceAdapter
     }
 
     @Override
+    public List<PostWithIdAndAuthorVo> loadTopPostsByBookmarkCount(
+            FindTopPostsByBookmarkCountQuery query) {
+        return postRepository.findTopNPostsByBookmarkCount(query.getLimit());
+    }
+
+    @Override
     public List<PostWithUserAndBookmarkCountVo> loadPostWithUserAndBookmarkCount(
             FindByIdsQuery query) {
         return postRepository.findAllPostsWithUserAndBookmarkCount(query);

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepository.java
@@ -3,6 +3,7 @@ package com.ftm.server.adapter.out.persistence.repository;
 import com.ftm.server.application.query.FindByIdsQuery;
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
+import com.ftm.server.application.vo.post.PostWithIdAndAuthorVo;
 import com.ftm.server.application.vo.post.PostWithUserAndBookmarkCountVo;
 import com.ftm.server.application.vo.post.UserWithPostCountVo;
 import java.util.List;
@@ -15,4 +16,6 @@ public interface PostWithBookmarkCustomRepository {
             FindPostsByCreatedDateQuery query);
 
     List<PostWithUserAndBookmarkCountVo> findAllPostsWithUserAndBookmarkCount(FindByIdsQuery query);
+
+    List<PostWithIdAndAuthorVo> findTopNPostsByBookmarkCount(int limit);
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepositoryImpl.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepositoryImpl.java
@@ -6,6 +6,7 @@ import static com.ftm.server.adapter.out.persistence.model.QPostJpaEntity.postJp
 import com.ftm.server.application.query.FindByIdsQuery;
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.vo.post.PostWithBookmarkCountVo;
+import com.ftm.server.application.vo.post.PostWithIdAndAuthorVo;
 import com.ftm.server.application.vo.post.PostWithUserAndBookmarkCountVo;
 import com.ftm.server.application.vo.post.UserWithPostCountVo;
 import com.ftm.server.domain.enums.UserRole;
@@ -113,6 +114,20 @@ public class PostWithBookmarkCustomRepositoryImpl implements PostWithBookmarkCus
                         postJpaEntity.hashtags,
                         postJpaEntity.viewCount,
                         postJpaEntity.likeCount)
+                .fetch();
+    }
+
+    @Override
+    public List<PostWithIdAndAuthorVo> findTopNPostsByBookmarkCount(int limit) {
+        return queryFactory
+                .select(Projections.constructor(PostWithIdAndAuthorVo.class, postJpaEntity.id))
+                .from(postJpaEntity)
+                .leftJoin(bookmarkJpaEntity)
+                .on(bookmarkJpaEntity.post.eq(postJpaEntity))
+                .where(postJpaEntity.isDeleted.eq(false))
+                .groupBy(postJpaEntity.id)
+                .orderBy(bookmarkJpaEntity.id.countDistinct().desc(), postJpaEntity.id.desc())
+                .limit(limit)
                 .fetch();
     }
 }

--- a/src/main/java/com/ftm/server/adapter/out/scheduler/GetUserPickTopBookmarkPostsScheduler.java
+++ b/src/main/java/com/ftm/server/adapter/out/scheduler/GetUserPickTopBookmarkPostsScheduler.java
@@ -1,0 +1,26 @@
+package com.ftm.server.adapter.out.scheduler;
+
+import com.ftm.server.application.port.out.cache.LoadUserPickTopBookmarkPostsWithCachePort;
+import com.ftm.server.common.annotation.Adapter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@Adapter
+@RequiredArgsConstructor
+public class GetUserPickTopBookmarkPostsScheduler {
+
+    private final LoadUserPickTopBookmarkPostsWithCachePort cachePort;
+
+    // cache TTL 1시간 만료 전에 주기적으로 58분 간격으로 갱신
+    @Scheduled(fixedRateString = "PT58M", initialDelayString = "PT1M")
+    public void run() {
+        log.info(
+                "Loading UserPick Top Bookmark Posts at {}",
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        cachePort.getTopBookmarkPostsCachePut();
+    }
+}

--- a/src/main/java/com/ftm/server/application/port/in/post/LoadUserPickTopBookmarkPostsUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/post/LoadUserPickTopBookmarkPostsUseCase.java
@@ -1,0 +1,8 @@
+package com.ftm.server.application.port.in.post;
+
+import com.ftm.server.application.vo.post.LoadUserPickTopBookmarkPostsVo;
+import java.util.List;
+
+public interface LoadUserPickTopBookmarkPostsUseCase {
+    List<LoadUserPickTopBookmarkPostsVo> execute();
+}

--- a/src/main/java/com/ftm/server/application/port/out/cache/LoadUserPickTopBookmarkPostsWithCachePort.java
+++ b/src/main/java/com/ftm/server/application/port/out/cache/LoadUserPickTopBookmarkPostsWithCachePort.java
@@ -1,0 +1,11 @@
+package com.ftm.server.application.port.out.cache;
+
+import com.ftm.server.application.vo.post.PostWithIdAndAuthorVo;
+import java.util.List;
+
+public interface LoadUserPickTopBookmarkPostsWithCachePort {
+
+    List<PostWithIdAndAuthorVo> getTopBookmarkPosts();
+
+    List<PostWithIdAndAuthorVo> getTopBookmarkPostsCachePut();
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostPort.java
@@ -19,4 +19,6 @@ public interface LoadPostPort {
     List<Post> loadUserPickPopularPosts(FindUserPickPopularPostsQuery query);
 
     List<PostWithIdAndAuthorVo> loadUserPickBiblePosts(FindUserPickBiblePostsQuery query);
+
+    List<PostWithIdAndAuthorVo> loadTopPostsByBookmarkCount(FindTopPostsByBookmarkCountQuery query);
 }

--- a/src/main/java/com/ftm/server/application/query/FindTopPostsByBookmarkCountQuery.java
+++ b/src/main/java/com/ftm/server/application/query/FindTopPostsByBookmarkCountQuery.java
@@ -1,0 +1,14 @@
+package com.ftm.server.application.query;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindTopPostsByBookmarkCountQuery {
+    private final int limit;
+
+    public static FindTopPostsByBookmarkCountQuery of(int limit) {
+        return new FindTopPostsByBookmarkCountQuery(limit);
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/post/LoadUserPickTopBookmarkPostsService.java
+++ b/src/main/java/com/ftm/server/application/service/post/LoadUserPickTopBookmarkPostsService.java
@@ -1,0 +1,79 @@
+package com.ftm.server.application.service.post;
+
+import com.ftm.server.application.port.in.post.LoadUserPickTopBookmarkPostsUseCase;
+import com.ftm.server.application.port.out.cache.LoadUserPickTopBookmarkPostsWithCachePort;
+import com.ftm.server.application.port.out.persistence.post.LoadPostImagePort;
+import com.ftm.server.application.port.out.persistence.post.LoadPostWithBookmarkCountPort;
+import com.ftm.server.application.query.FindByIdsQuery;
+import com.ftm.server.application.vo.post.LoadUserPickTopBookmarkPostsVo;
+import com.ftm.server.application.vo.post.PostWithIdAndAuthorVo;
+import com.ftm.server.application.vo.post.PostWithUserAndBookmarkCountVo;
+import com.ftm.server.common.consts.PropertiesHolder;
+import com.ftm.server.domain.entity.PostImage;
+import com.ftm.server.domain.enums.PostHashtag;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoadUserPickTopBookmarkPostsService implements LoadUserPickTopBookmarkPostsUseCase {
+
+    private final LoadUserPickTopBookmarkPostsWithCachePort cachePort;
+    private final LoadPostWithBookmarkCountPort loadPostWithBookmarkCountPort;
+    private final LoadPostImagePort loadPostImagePort;
+
+    @Override
+    public List<LoadUserPickTopBookmarkPostsVo> execute() {
+        // 1) 캐시에서 상위 id 목록 조회 (4개)
+        List<PostWithIdAndAuthorVo> postList = cachePort.getTopBookmarkPosts();
+        if (postList.isEmpty()) return List.of();
+
+        // 2) id 목록
+        List<Long> postIds = postList.stream().map(PostWithIdAndAuthorVo::getPostId).toList();
+
+        // 3) 상세 조회 (유저/북마크 수 포함)
+        Map<Long, PostWithUserAndBookmarkCountVo> detailPostMap =
+                loadPostWithBookmarkCountPort
+                        .loadPostWithUserAndBookmarkCount(FindByIdsQuery.from(postIds))
+                        .stream()
+                        .collect(Collectors.toMap(PostWithUserAndBookmarkCountVo::getId, vo -> vo));
+
+        // 4) 대표 이미지
+        List<PostImage> postImages =
+                loadPostImagePort.loadRepresentativeImagesByPostIds(FindByIdsQuery.from(postIds));
+        Map<Long, String> imageUrlMap =
+                postImages.stream()
+                        .collect(
+                                java.util.stream.Collectors.toMap(
+                                        PostImage::getPostId,
+                                        PostImage::getObjectKey,
+                                        (a, b) -> a));
+
+        // 5) 합치기 (postList 순서 = 랭킹)
+        return IntStream.range(0, postIds.size())
+                .mapToObj(
+                        i -> {
+                            Long postId = postIds.get(i);
+                            PostWithUserAndBookmarkCountVo p = detailPostMap.get(postId);
+                            int ranking = i + 1;
+                            String imageUrl =
+                                    imageUrlMap.getOrDefault(
+                                            p.getId(), PropertiesHolder.POST_DEFAULT_IMAGE);
+                            List<String> hashtags =
+                                    p.getHashtags() == null || p.getHashtags().length == 0
+                                            ? List.of()
+                                            : Arrays.stream(p.getHashtags())
+                                                    .map(PostHashtag::getTag)
+                                                    .toList();
+                            return LoadUserPickTopBookmarkPostsVo.of(
+                                    ranking,
+                                    p,
+                                    PropertiesHolder.CDN_PATH + "/" + imageUrl,
+                                    hashtags);
+                        })
+                .toList();
+    }
+}

--- a/src/main/java/com/ftm/server/application/vo/post/LoadUserPickTopBookmarkPostsVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/LoadUserPickTopBookmarkPostsVo.java
@@ -1,0 +1,38 @@
+package com.ftm.server.application.vo.post;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoadUserPickTopBookmarkPostsVo {
+    private final Integer ranking;
+    private final Long postId;
+    private final String title;
+    private final Long authorId;
+    private final String authorName;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Long scrapCount;
+    private final String imageUrl;
+    private final List<String> hashtags;
+
+    public static LoadUserPickTopBookmarkPostsVo of(
+            Integer ranking,
+            PostWithUserAndBookmarkCountVo post,
+            String imageUrl,
+            List<String> hashtags) {
+        return new LoadUserPickTopBookmarkPostsVo(
+                ranking,
+                post.getId(),
+                post.getTitle(),
+                post.getUserId(),
+                post.getUserName(),
+                post.getViewCount(),
+                post.getLikeCount(),
+                post.getScrapCount(),
+                imageUrl,
+                hashtags);
+    }
+}

--- a/src/main/java/com/ftm/server/common/consts/StaticConsts.java
+++ b/src/main/java/com/ftm/server/common/consts/StaticConsts.java
@@ -24,4 +24,8 @@ public class StaticConsts {
 
     public static final String USER_PICK_BIBLE_POSTS_CACHE_NAME = "ftm:posts:userpick:bible";
     public static final String USER_PICK_BIBLE_POSTS_CACHE_KEY_ALL = "'all'";
+
+    public static final String USER_PICK_TOP_BOOKMARK_POSTS_CACHE_NAME =
+            "ftm:posts:userpick:top-bookmarks";
+    public static final String USER_PICK_TOP_BOOKMARK_POSTS_CACHE_KEY_ALL = "'all'";
 }

--- a/src/main/java/com/ftm/server/infrastructure/cache/CaffeineCacheConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/cache/CaffeineCacheConfig.java
@@ -56,4 +56,11 @@ public class CaffeineCacheConfig {
                         .expireAfterWrite(1, TimeUnit.HOURS));
         return mgr;
     }
+
+    @Bean("userPickTopBookmarkPostsCacheManager") // 유저픽 게시글 - 북마크 상위 게시물 용 캐시 매니저
+    public CaffeineCacheManager cacheManagerForUserPickTopBookmarkPosts() {
+        CaffeineCacheManager mgr = new CaffeineCacheManager();
+        mgr.setCaffeine(Caffeine.newBuilder().maximumSize(10).expireAfterWrite(1, TimeUnit.HOURS));
+        return mgr;
+    }
 }

--- a/src/test/java/com/ftm/server/post/LoadUserPickTopBookmarkPostsTest.java
+++ b/src/test/java/com/ftm/server/post/LoadUserPickTopBookmarkPostsTest.java
@@ -1,0 +1,129 @@
+package com.ftm.server.post;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.in.web.post.dto.request.SavePostRequest;
+import com.ftm.server.application.command.post.SavePostCommand;
+import com.ftm.server.application.port.out.persistence.post.SavePostPort;
+import com.ftm.server.domain.entity.Post;
+import com.ftm.server.domain.entity.User;
+import com.ftm.server.domain.enums.PostHashtag;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class LoadUserPickTopBookmarkPostsTest extends BaseTest {
+
+    @Autowired private SavePostPort savePostPort;
+
+    private final List<FieldDescriptor> responseFields =
+            List.of(
+                    fieldWithPath("status").type(NUMBER).description("응답 상태"),
+                    fieldWithPath("code").type(STRING).description("상태 코드"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data")
+                            .type(ARRAY)
+                            .optional()
+                            .description("응답 데이터 : 대상 게시물이 없는 경우 빈 배열"),
+                    fieldWithPath("data[].ranking").type(NUMBER).description("순위"),
+                    fieldWithPath("data[].postId").type(NUMBER).description("게시글 ID"),
+                    fieldWithPath("data[].title").type(STRING).description("게시글 제목"),
+                    fieldWithPath("data[].authorId").type(NUMBER).description("작성자 user ID"),
+                    fieldWithPath("data[].authorName").type(STRING).description("작성자 이름"),
+                    fieldWithPath("data[].viewCount").type(NUMBER).description("조회수"),
+                    fieldWithPath("data[].likeCount").type(NUMBER).description("좋아요 수"),
+                    fieldWithPath("data[].scrapCount").type(NUMBER).description("스크랩 수"),
+                    fieldWithPath("data[].imageUrl").type(STRING).description("이미지 url"),
+                    fieldWithPath("data[].hashtags")
+                            .type(ARRAY)
+                            .description("게시글 해시태그 : 한글 태그 표시. 없는 경우 빈 배열([])로 표시"));
+
+    private ResultActions getResultActions() throws Exception {
+        return mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/api/posts/userpick/top-bookmarks"));
+    }
+
+    private RestDocumentationResultHandler getDocument(Integer identifier) {
+        return document(
+                "loadUserPickTopBookmark/" + identifier,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint(), getModifiedHeader()),
+                responseFields(responseFields),
+                resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("유저픽 게시글")
+                                .summary("\"그루밍 바이블\" 목록 조회 api")
+                                .description("그루밍 라운지 내 \"다시 찾아보고 싶은 그루밍\" 목록 조회 api 입니다.")
+                                .responseFields(responseFields)
+                                .build()));
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("테스트 성공")
+    public void test1() throws Exception {
+        // given
+
+        SessionAndUser sessionAndUser = createUserAndLoginAndReturnUser(); // 로그인 처리
+
+        User user = sessionAndUser.user();
+
+        // test 용 post 생성
+        savePostPort.savePost(
+                Post.create(
+                        SavePostCommand.from(
+                                user.getId(),
+                                new SavePostRequest(
+                                        "test1",
+                                        List.of(PostHashtag.SUN_CARE, PostHashtag.CLEANSING),
+                                        "content1",
+                                        new ArrayList<>()),
+                                new ArrayList<>(),
+                                new ArrayList<>())));
+
+        savePostPort.savePost(
+                Post.create(
+                        SavePostCommand.from(
+                                user.getId(),
+                                new SavePostRequest(
+                                        "test2",
+                                        List.of(
+                                                PostHashtag.BOTTOM_CLOTHING,
+                                                PostHashtag.FASHION_ACCESSORIES),
+                                        "content2",
+                                        new ArrayList<>()),
+                                new ArrayList<>(),
+                                new ArrayList<>())));
+
+        // when
+        ResultActions resultActions = getResultActions();
+
+        // then
+        resultActions
+                .andExpect(status().is(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.data", hasSize(2)));
+
+        // documentation
+        resultActions.andDo(getDocument(1));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #155 

## 📌 작업 내용 및 특이사항

- 다시 찾아보고 싶은 그루밍 목록 조회 api 추가했습니다.
- 북마크 누적 순으로 상위 3개의 게시물을 조회하는 api입니다.
- 기존 그루밍 라운지 게시글 조회 api와 마찬가지로, 상위 3개 게시글의 id를 cache에 저장해두고, 요청이 들어올 때마다 post id값으로 상세 데이터를 조회하도록 하고 있습니다. 

## 🔍 참고사항

-

## 📚 기타

-