### PR TITLE
feat:그루밍 이야기 - 게시글 최신순 조회 api 구현(#158)

### DIFF
--- a/src/docs/asciidoc/post-api.adoc
+++ b/src/docs/asciidoc/post-api.adoc
@@ -305,3 +305,22 @@ include::{snippetsDir}/loadUserPickTopBookmark/1/http-response.adoc[]
 include::{snippetsDir}/loadUserPickTopBookmark/1/response-fields.adoc[]
 
 ---
+
+=== **12. 그루밍 이야기 - "최신순" 조회**
+
+무한 스크롤 - cursor 방식으로 구현했습니다.
+
+==== Request
+include::{snippetsDir}/loadUserPickAllLatest/1/http-request.adoc[]
+
+==== Request Query Parameters
+include::{snippetsDir}/loadUserPickAllLatest/1/query-parameters.adoc[]
+
+==== 성공 Response
+include::{snippetsDir}/loadUserPickAllLatest/1/http-response.adoc[]
+
+==== Response Body Fields
+include::{snippetsDir}/loadUserPickAllLatest/1/response-fields.adoc[]
+
+
+---

--- a/src/main/java/com/ftm/server/adapter/in/web/post/controller/GetUserPickPostsController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/controller/GetUserPickPostsController.java
@@ -1,0 +1,42 @@
+package com.ftm.server.adapter.in.web.post.controller;
+
+import com.ftm.server.adapter.in.web.post.dto.response.GetUserPickPostsLatestResponse;
+import com.ftm.server.application.port.in.post.GetUserPickPostsUseCase;
+import com.ftm.server.application.query.FindUserPickLatestPostsByCursorQuery;
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import com.ftm.server.infrastructure.security.UserPrincipal;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GetUserPickPostsController {
+
+    private final GetUserPickPostsUseCase getUserPickPostsUseCase;
+
+    @GetMapping("/api/posts/userpick/all/latest")
+    public ResponseEntity<ApiResponse> getLatestPosts(
+            @RequestParam(required = false, name = "lastCursor")
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                    LocalDateTime nextCursorCreatedAt,
+            @RequestParam(required = false, defaultValue = "20") int limit,
+            @AuthenticationPrincipal UserPrincipal user) {
+
+        GetUserPickPostsLatestResponse result =
+                GetUserPickPostsLatestResponse.from(
+                        getUserPickPostsUseCase.executeLatest(
+                                FindUserPickLatestPostsByCursorQuery.of(
+                                        limit,
+                                        nextCursorCreatedAt,
+                                        user == null ? null : user.getId())));
+
+        return ResponseEntity.ok(ApiResponse.success(SuccessResponseCode.OK, result));
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/GetUserPickPostsLatestResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/GetUserPickPostsLatestResponse.java
@@ -1,0 +1,22 @@
+package com.ftm.server.adapter.in.web.post.dto.response;
+
+import com.ftm.server.application.vo.post.GetUserPickAllPostsLatestWithCursorVo;
+import com.ftm.server.application.vo.post.GetUserPickPostsVo;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class GetUserPickPostsLatestResponse {
+
+    private List<GetUserPickPostsVo> data;
+    private LocalDateTime nextCursorDateTime; // 다음 요청을 위한 datetime
+    private Boolean hasNext;
+
+    public static GetUserPickPostsLatestResponse from(GetUserPickAllPostsLatestWithCursorVo vo) {
+        return new GetUserPickPostsLatestResponse(
+                vo.getPostList(), vo.getNextCursorDateTime(), vo.getHasNext());
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
@@ -169,6 +169,18 @@ public class PostDomainPersistenceAdapter
     }
 
     @Override
+    public List<BookmarkYnWrapperVo> loadUserPickAllPostsByLatest(
+            FindUserPickLatestPostsByCursorQuery query) {
+        return postRepository.findPostsByLatestCursor(query).stream()
+                .map(
+                        e ->
+                                new BookmarkYnWrapperVo(
+                                        e.getBookmarkYn(),
+                                        postMapper.toDomainEntity((PostJpaEntity) e.getData())))
+                .toList();
+    }
+
+    @Override
     public List<PostWithUserAndBookmarkCountVo> loadPostWithUserAndBookmarkCount(
             FindByIdsQuery query) {
         return postRepository.findAllPostsWithUserAndBookmarkCount(query);

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostCustomRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostCustomRepository.java
@@ -4,6 +4,8 @@ import com.ftm.server.adapter.out.persistence.model.PostJpaEntity;
 import com.ftm.server.application.query.FindPostByDeleteOptionQuery;
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.query.FindPostsByPagingQuery;
+import com.ftm.server.application.query.FindUserPickLatestPostsByCursorQuery;
+import com.ftm.server.application.vo.post.BookmarkYnWrapperVo;
 import com.querydsl.core.Tuple;
 import java.util.List;
 import org.springframework.data.domain.Slice;
@@ -15,4 +17,6 @@ public interface PostCustomRepository {
     Slice<PostJpaEntity> findAllByUserIdWithPaging(FindPostsByPagingQuery query);
 
     List<Tuple> findAllByCreatedDateInOneWeekAndUserGrouping(FindPostsByCreatedDateQuery query);
+
+    List<BookmarkYnWrapperVo> findPostsByLatestCursor(FindUserPickLatestPostsByCursorQuery query);
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostCustomRepositoryImpl.java
@@ -1,12 +1,18 @@
 package com.ftm.server.adapter.out.persistence.repository;
 
+import static com.ftm.server.adapter.out.persistence.model.QBookmarkJpaEntity.bookmarkJpaEntity;
 import static com.ftm.server.adapter.out.persistence.model.QPostJpaEntity.postJpaEntity;
 
 import com.ftm.server.adapter.out.persistence.model.PostJpaEntity;
 import com.ftm.server.application.query.FindPostByDeleteOptionQuery;
 import com.ftm.server.application.query.FindPostsByCreatedDateQuery;
 import com.ftm.server.application.query.FindPostsByPagingQuery;
+import com.ftm.server.application.query.FindUserPickLatestPostsByCursorQuery;
+import com.ftm.server.application.vo.post.BookmarkYnWrapperVo;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -67,6 +73,60 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .from(postJpaEntity)
                 .groupBy(postJpaEntity.user)
                 .where(postJpaEntity.createdAt.goe(oneWeekAgo))
+                .fetch();
+    }
+
+    @Override
+    public List<BookmarkYnWrapperVo> findPostsByLatestCursor(
+            FindUserPickLatestPostsByCursorQuery query) {
+
+        BooleanBuilder condition = new BooleanBuilder();
+
+        // 커서가 있으면 조건 추가
+        if (query.getNextCursorCreatedAt() != null) {
+            condition.and(
+                    postJpaEntity.createdAt.lt(
+                            query.getNextCursorCreatedAt()) // createdAt이 더 작은 게시글
+                    );
+        }
+
+        if (query.getUserId() == null) {
+            return queryFactory
+                    .select(
+                            Projections.constructor(
+                                    BookmarkYnWrapperVo.class,
+                                    Expressions.constant(false),
+                                    postJpaEntity))
+                    .from(postJpaEntity)
+                    .where(condition)
+                    .orderBy(
+                            postJpaEntity.createdAt.desc(),
+                            postJpaEntity.id.desc()) // 최신순 + tie-breaker
+                    .limit(query.getLimit() + 1) // hasNext 체크를 위해 +1
+                    .fetch();
+        }
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                BookmarkYnWrapperVo.class,
+                                bookmarkJpaEntity.id.isNotNull(),
+                                postJpaEntity))
+                .from(postJpaEntity)
+                .leftJoin(bookmarkJpaEntity)
+                .on(
+                        bookmarkJpaEntity
+                                .post
+                                .eq(postJpaEntity)
+                                .and(
+                                        bookmarkJpaEntity.user.id.eq(
+                                                query.getUserId())) // 특정 user 북마크 여부 확인
+                        )
+                .where(condition)
+                .orderBy(
+                        postJpaEntity.createdAt.desc(),
+                        postJpaEntity.id.desc()) // 최신순 + tie-breaker
+                .limit(query.getLimit() + 1) // hasNext 체크를 위해 +1
                 .fetch();
     }
 }

--- a/src/main/java/com/ftm/server/application/port/in/post/GetUserPickPostsUseCase.java
+++ b/src/main/java/com/ftm/server/application/port/in/post/GetUserPickPostsUseCase.java
@@ -1,0 +1,11 @@
+package com.ftm.server.application.port.in.post;
+
+import com.ftm.server.application.query.FindUserPickLatestPostsByCursorQuery;
+import com.ftm.server.application.vo.post.GetUserPickAllPostsLatestWithCursorVo;
+import com.ftm.server.common.annotation.UseCase;
+
+@UseCase
+public interface GetUserPickPostsUseCase {
+
+    GetUserPickAllPostsLatestWithCursorVo executeLatest(FindUserPickLatestPostsByCursorQuery query);
+}

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadPostPort.java
@@ -1,6 +1,7 @@
 package com.ftm.server.application.port.out.persistence.post;
 
 import com.ftm.server.application.query.*;
+import com.ftm.server.application.vo.post.BookmarkYnWrapperVo;
 import com.ftm.server.application.vo.post.PostWithIdAndAuthorVo;
 import com.ftm.server.common.annotation.Port;
 import com.ftm.server.domain.entity.Post;
@@ -21,4 +22,7 @@ public interface LoadPostPort {
     List<PostWithIdAndAuthorVo> loadUserPickBiblePosts(FindUserPickBiblePostsQuery query);
 
     List<PostWithIdAndAuthorVo> loadTopPostsByBookmarkCount(FindTopPostsByBookmarkCountQuery query);
+
+    List<BookmarkYnWrapperVo> loadUserPickAllPostsByLatest(
+            FindUserPickLatestPostsByCursorQuery query);
 }

--- a/src/main/java/com/ftm/server/application/query/FindUserPickLatestPostsByCursorQuery.java
+++ b/src/main/java/com/ftm/server/application/query/FindUserPickLatestPostsByCursorQuery.java
@@ -1,0 +1,18 @@
+package com.ftm.server.application.query;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindUserPickLatestPostsByCursorQuery {
+    private final Integer limit;
+    private final LocalDateTime nextCursorCreatedAt;
+    private final Long userId;
+
+    public static FindUserPickLatestPostsByCursorQuery of(
+            Integer limit, LocalDateTime nextCursorCreatedAt, Long userId) {
+        return new FindUserPickLatestPostsByCursorQuery(limit, nextCursorCreatedAt, userId);
+    }
+}

--- a/src/main/java/com/ftm/server/application/service/post/GetUserPickAllPostsByLatestService.java
+++ b/src/main/java/com/ftm/server/application/service/post/GetUserPickAllPostsByLatestService.java
@@ -1,0 +1,96 @@
+package com.ftm.server.application.service.post;
+
+import static java.util.stream.Collectors.toMap;
+
+import com.ftm.server.application.port.in.post.GetUserPickPostsUseCase;
+import com.ftm.server.application.port.out.persistence.post.LoadPostImagePort;
+import com.ftm.server.application.port.out.persistence.post.LoadPostPort;
+import com.ftm.server.application.port.out.persistence.post.LoadPostWithBookmarkCountPort;
+import com.ftm.server.application.query.FindByIdsQuery;
+import com.ftm.server.application.query.FindUserPickLatestPostsByCursorQuery;
+import com.ftm.server.application.vo.post.*;
+import com.ftm.server.common.consts.PropertiesHolder;
+import com.ftm.server.domain.entity.Post;
+import com.ftm.server.domain.entity.PostImage;
+import com.ftm.server.domain.enums.PostHashtag;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserPickAllPostsByLatestService implements GetUserPickPostsUseCase {
+
+    private final LoadPostPort loadPostPort;
+    private final LoadPostWithBookmarkCountPort loadPostWithBookmarkCountPort;
+    private final LoadPostImagePort loadPostImagePort;
+
+    @Override
+    public GetUserPickAllPostsLatestWithCursorVo executeLatest(
+            FindUserPickLatestPostsByCursorQuery query) {
+
+        List<BookmarkYnWrapperVo> postsWithBookmarkYn =
+                loadPostPort.loadUserPickAllPostsByLatest(query); // 최신순으로 조회. 마지막 cursor 위치를 기준으로
+
+        if (postsWithBookmarkYn.isEmpty()) {
+            return GetUserPickAllPostsLatestWithCursorVo.of(List.of(), false, null);
+        }
+
+        boolean hasNext = false;
+        LocalDateTime lastCreatedAt = null;
+        if (postsWithBookmarkYn.size() > query.getLimit()) {
+            hasNext = true;
+            postsWithBookmarkYn = postsWithBookmarkYn.subList(0, query.getLimit());
+            lastCreatedAt =
+                    ((Post) postsWithBookmarkYn.get(query.getLimit() - 1).getData()).getCreatedAt();
+        }
+
+        List<GetUserPickPostsVo> result = convertToVo(postsWithBookmarkYn.stream().toList());
+
+        return GetUserPickAllPostsLatestWithCursorVo.of(result, hasNext, lastCreatedAt);
+    }
+
+    private List<GetUserPickPostsVo> convertToVo(List<BookmarkYnWrapperVo> posts) {
+
+        List<Long> postIds = posts.stream().map(b -> ((Post) b.getData()).getId()).toList();
+
+        Map<Long, PostWithUserAndBookmarkCountVo> detailPostMap =
+                loadPostWithBookmarkCountPort
+                        .loadPostWithUserAndBookmarkCount(FindByIdsQuery.from(postIds))
+                        .stream()
+                        .collect(toMap(PostWithUserAndBookmarkCountVo::getId, vo -> vo));
+
+        Map<Long, String> imageUrlMap =
+                loadPostImagePort
+                        .loadRepresentativeImagesByPostIds(FindByIdsQuery.from(postIds))
+                        .stream()
+                        .collect(toMap(PostImage::getPostId, PostImage::getObjectKey, (a, b) -> a));
+
+        return posts.stream()
+                .map(
+                        b -> {
+                            PostWithUserAndBookmarkCountVo p =
+                                    detailPostMap.get(((Post) b.getData()).getId());
+                            String imageUrl =
+                                    imageUrlMap.getOrDefault(
+                                            p.getId(), PropertiesHolder.POST_DEFAULT_IMAGE);
+                            List<String> hashtags = toHashtagList(p.getHashtags());
+
+                            return GetUserPickPostsVo.of(
+                                    p,
+                                    PropertiesHolder.CDN_PATH + "/" + imageUrl,
+                                    hashtags,
+                                    b.getBookmarkYn());
+                        })
+                .toList();
+    }
+
+    private List<String> toHashtagList(PostHashtag[] hashtags) {
+        return (hashtags == null || hashtags.length == 0)
+                ? List.of()
+                : Arrays.stream(hashtags).map(PostHashtag::getTag).toList();
+    }
+}

--- a/src/main/java/com/ftm/server/application/vo/post/BookmarkYnWrapperVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/BookmarkYnWrapperVo.java
@@ -1,0 +1,11 @@
+package com.ftm.server.application.vo.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class BookmarkYnWrapperVo<T> {
+    Boolean bookmarkYn;
+    T data;
+}

--- a/src/main/java/com/ftm/server/application/vo/post/GetUserPickAllPostsLatestWithCursorVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/GetUserPickAllPostsLatestWithCursorVo.java
@@ -1,0 +1,20 @@
+package com.ftm.server.application.vo.post;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetUserPickAllPostsLatestWithCursorVo {
+
+    List<GetUserPickPostsVo> postList;
+    Boolean hasNext;
+    LocalDateTime nextCursorDateTime;
+
+    public static GetUserPickAllPostsLatestWithCursorVo of(
+            List<GetUserPickPostsVo> postList, Boolean hasNext, LocalDateTime nextCursorDateTime) {
+        return new GetUserPickAllPostsLatestWithCursorVo(postList, hasNext, nextCursorDateTime);
+    }
+}

--- a/src/main/java/com/ftm/server/application/vo/post/GetUserPickPostsVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/GetUserPickPostsVo.java
@@ -1,0 +1,38 @@
+package com.ftm.server.application.vo.post;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetUserPickPostsVo {
+    private final Long postId;
+    private final String title;
+    private final Long authorId;
+    private final String authorName;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Long scrapCount;
+    private final String imageUrl;
+    private final List<String> hashtags;
+    private final Boolean userBookmarkYn;
+
+    public static GetUserPickPostsVo of(
+            PostWithUserAndBookmarkCountVo post,
+            String imageUrl,
+            List<String> hashtags,
+            Boolean userBookmarkYn) {
+        return new GetUserPickPostsVo(
+                post.getId(),
+                post.getTitle(),
+                post.getUserId(),
+                post.getUserName(),
+                post.getViewCount(),
+                post.getLikeCount(),
+                post.getScrapCount(),
+                imageUrl,
+                hashtags,
+                userBookmarkYn);
+    }
+}

--- a/src/test/java/com/ftm/server/post/LoadUserPickLatestPostsTest.java
+++ b/src/test/java/com/ftm/server/post/LoadUserPickLatestPostsTest.java
@@ -1,0 +1,161 @@
+package com.ftm.server.post;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.ftm.server.BaseTest;
+import com.ftm.server.adapter.in.web.post.dto.request.SavePostRequest;
+import com.ftm.server.application.command.post.SavePostCommand;
+import com.ftm.server.application.port.out.persistence.post.SavePostPort;
+import com.ftm.server.domain.entity.Post;
+import com.ftm.server.domain.entity.User;
+import com.ftm.server.domain.enums.PostHashtag;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.request.ParameterDescriptor;
+import org.springframework.restdocs.snippet.Attributes;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+public class LoadUserPickLatestPostsTest extends BaseTest {
+
+    @Autowired private SavePostPort savePostPort;
+
+    private final List<ParameterDescriptor> queryParameters =
+            List.of(
+                    parameterWithName("limit")
+                            .description("한번 로딩 시 불러올 게시글의 개수")
+                            .attributes(new Attributes.Attribute("constraint", "Integer")),
+                    parameterWithName("lastCursor")
+                            .optional()
+                            .description("이전 로딩의 마지막 커서 시점 입력")
+                            .attributes(
+                                    new Attributes.Attribute(
+                                            "constraint",
+                                            "YYYY-MM-DDTHH:mm:SS.msss , 이전 스크롤 로딩 응답값(nextCursorDateTime) 필드 그대로 사용. 첫번째 스크롤인 경우 전달 X")));
+
+    private final List<FieldDescriptor> responseFields =
+            List.of(
+                    fieldWithPath("status").type(NUMBER).description("응답 상태"),
+                    fieldWithPath("code").type(STRING).description("상태 코드"),
+                    fieldWithPath("message").type(STRING).description("메시지"),
+                    fieldWithPath("data").type(OBJECT).optional().description("응답 데이터"),
+                    fieldWithPath("data.data")
+                            .type(ARRAY)
+                            .optional()
+                            .description("응답 데이터가 없으면 빈 배열"),
+                    fieldWithPath("data.data[].postId").type(NUMBER).description("게시글 ID"),
+                    fieldWithPath("data.data[].title").type(STRING).description("게시글 제목"),
+                    fieldWithPath("data.data[].authorId").type(NUMBER).description("작성자 user ID"),
+                    fieldWithPath("data.data[].authorName").type(STRING).description("작성자 이름"),
+                    fieldWithPath("data.data[].viewCount").type(NUMBER).description("조회수"),
+                    fieldWithPath("data.data[].likeCount").type(NUMBER).description("좋아요 수"),
+                    fieldWithPath("data.data[].scrapCount").type(NUMBER).description("스크랩 수"),
+                    fieldWithPath("data.data[].imageUrl").type(STRING).description("이미지 url"),
+                    fieldWithPath("data.data[].hashtags")
+                            .type(ARRAY)
+                            .description("게시글 해시태그 : 한글 태그 표시. 없는 경우 빈 배열([])로 표시"),
+                    fieldWithPath("data.data[].userBookmarkYn")
+                            .type(BOOLEAN)
+                            .description("사용자 북마크 등록 여부"),
+                    fieldWithPath("data.nextCursorDateTime")
+                            .type(STRING)
+                            .optional()
+                            .description("다음 스크롤 로딩 요청 시, 요청 파라미터 lastCursor의 값이 됨")
+                            .attributes(
+                                    new Attributes.Attribute(
+                                            "nullable", "hasNext가 false인 경우 null")),
+                    fieldWithPath("data.hasNext")
+                            .type(BOOLEAN)
+                            .description("불러올 게시글이 추가로 남았는지 여부"));
+
+    private ResultActions getResultActions() throws Exception {
+        return mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/api/posts/userpick/all/latest")
+                        .queryParam("limit", "5"));
+    }
+
+    private RestDocumentationResultHandler getDocument(Integer identifier) {
+        return document(
+                "loadUserPickAllLatest/" + identifier,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint(), getModifiedHeader()),
+                responseFields(responseFields),
+                queryParameters(queryParameters),
+                resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("유저픽 게시글")
+                                .summary("\"그루밍 이야기\" 최신순 조회 api")
+                                .description("그루밍 라운지 내 \"그루밍 이야기\" 최신순 목록 조회 api 입니다.")
+                                .responseFields(responseFields)
+                                .build()));
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("테스트 성공")
+    public void test1() throws Exception {
+        // given
+
+        SessionAndUser sessionAndUser = createUserAndLoginAndReturnUser(); // 로그인 처리
+
+        User user = sessionAndUser.user();
+
+        // test 용 post 생성
+        savePostPort.savePost(
+                Post.create(
+                        SavePostCommand.from(
+                                user.getId(),
+                                new SavePostRequest(
+                                        "test1",
+                                        List.of(PostHashtag.SUN_CARE, PostHashtag.CLEANSING),
+                                        "content1",
+                                        new ArrayList<>()),
+                                new ArrayList<>(),
+                                new ArrayList<>())));
+
+        savePostPort.savePost(
+                Post.create(
+                        SavePostCommand.from(
+                                user.getId(),
+                                new SavePostRequest(
+                                        "test2",
+                                        List.of(
+                                                PostHashtag.BOTTOM_CLOTHING,
+                                                PostHashtag.FASHION_ACCESSORIES),
+                                        "content2",
+                                        new ArrayList<>()),
+                                new ArrayList<>(),
+                                new ArrayList<>())));
+
+        // when
+        ResultActions resultActions = getResultActions();
+
+        // then
+        resultActions
+                .andExpect(status().is(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.data.data", hasSize(2)));
+
+        // documentation
+        resultActions.andDo(getDocument(1));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #158

## 📌 작업 내용 및 특이사항

- 그루밍 이야기 내 게시글 최신순 조회 api 구현
- 최신순/인기순을 하나의 api로 생성하여 query param 등의 filter로 구분하려고 했으나, 두 api의 응답값 혹은 query param의 성격이 상당히 다르다고 판단하여 두개의 서로 다른 api로 분리하였습니다.
- 최신순 조회의 경우 무한 스크롤 cursor 방식으로 구현했습니다.
- hasNext, nextCursor 를 응답값으로 내려주고 있습니다.
- 로그인한 사용자의 경우, 각 게시글을 북마크로 등록했는지 여부를 확인하고 있습니다.
- 로그인하지 않은 사용자의 경우, 북마크 등록 여부 확인 없이 false 내려주고 있습니다. 

## 🔍 참고사항

-

## 📚 기타

-