### PR TITLE
chore: 인프라 환경 변경 테스트 (#172)

### DIFF
--- a/.github/workflows/develop-build-deploy-gce-manual.yml
+++ b/.github/workflows/develop-build-deploy-gce-manual.yml
@@ -1,0 +1,123 @@
+name: develop push Build and Deploy (GCE)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "배포할 브랜치 (수동 테스트 전용)"
+        required: true
+        default: "chore/#172"
+
+env:
+  DOCKERHUB_USERNAME: fittheman
+  DOCKERHUB_IMAGE_NAME: fittheman-server
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    environment: DEV
+
+    steps:
+      # 체크아웃
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      # JDK 17 세팅
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # 테스트 환경에서 필요한 컨테이너 실행 (redis, postgres)
+      - name: Run Containers
+        run: docker compose -f ./docker-compose-test.yml up -d
+
+      # 테스트 환경에서 필요한 스키마, 데이터 등록
+      - name: Apply Schema and Data
+        env:
+          TEST_POSTGRES_CONTAINER_NAME: "${{ github.event.repository.name }}-postgres-1"
+          TEST_POSTGRES_USER: test
+          TEST_POSTGRES_DB: ftm_test_db
+        run: |
+          echo "⏳ Waiting for postgres to be ready..."
+          until docker exec -i $TEST_POSTGRES_CONTAINER_NAME pg_isready -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB; do
+            echo "postgres is not ready yet. Retrying in 3 seconds..."
+            sleep 3
+          done
+          echo "✅ postgres is ready!"
+
+          echo "${{ secrets.SCHEMA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+          echo "${{ secrets.DATA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+
+      # Gradlew 실행 권한 허용
+      - name: Grant Execute Permission for Gradlew
+        run: chmod +x ./gradlew
+
+      # .env 파일 생성
+      - name: Load secrets into .env file
+        run: |
+          echo "${{ secrets.ENV }}" >> .env
+
+      # Swagger API 문서화 task 실행
+      - name: Apply Swagger API Document Task
+        run: ./gradlew copyOasToSwagger
+
+      # Rest Docs API 문서화 task 실행
+      - name: Apply Rest Docs API Document Task
+        run: ./gradlew copyDocument
+
+      # Gradle 빌드
+      - name: Build with Gradle
+        id: gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            bootJar
+            --scan
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+      # Dockerhub 로그인
+      - name: Login to Dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      # Docker 메타데이터
+      - name: Extract Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v5.5.0
+        env:
+          DOCKERHUB_IMAGE_FULL_NAME: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE_FULL_NAME }}
+          tags: |
+            type=sha,prefix=
+
+      # Docker 이미지 빌드, 도커허브 푸시
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}  # 추출된 도커 메타데이터 tags -> "${DOCKERHUB_USERNAME}/${DOCKERHUB_IMAGE_NAME}:{TAG}
+
+      # GCE 배포
+      - name: Deploy to GCE Server
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          IMAGE_FULL_PATH: ${{ steps.metadata.outputs.tags }}
+          DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}
+        with:
+          host: ${{ secrets.GCE_HOST }}
+          username: ${{ secrets.GCE_USER }}
+          key: ${{ secrets.GCE_SSH_PRIVATE_KEY }}
+          envs: IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME # docker-compose.yml 에서 사용할 환경 변수
+          debug: true
+          script: |
+            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+            docker compose up -d
+            docker image prune -a -f

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -1,140 +1,140 @@
-name: develop push Build and Deploy
-
-on:
-  push:
-    branches: [ "develop" ]
-
-env:
-  DOCKERHUB_USERNAME: fittheman
-  DOCKERHUB_IMAGE_NAME: fittheman-server
-
-jobs:
-  build-deploy:
-    runs-on: ubuntu-latest
-    environment: DEV
-
-    steps:
-      # 체크아웃
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # JDK 17 세팅
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      # 테스트 환경에서 필요한 컨테이너 실행 (redis, postgres)
-      - name: Run Containers
-        run: docker compose -f ./docker-compose-test.yml up -d
-
-      # 테스트 환경에서 필요한 스키마, 데이터 등록
-      - name: Apply Schema and Data
-        env:
-          TEST_POSTGRES_CONTAINER_NAME: "${{ github.event.repository.name }}-postgres-1"
-          TEST_POSTGRES_USER: test
-          TEST_POSTGRES_DB: ftm_test_db
-        run: |
-          echo "⏳ Waiting for postgres to be ready..."
-          until docker exec -i $TEST_POSTGRES_CONTAINER_NAME pg_isready -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB; do
-            echo "postgres is not ready yet. Retrying in 3 seconds..."
-            sleep 3
-          done
-          echo "✅ postgres is ready!"
-
-          echo "${{ secrets.SCHEMA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
-          echo "${{ secrets.DATA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
-
-      # Gradlew 실행 권한 허용
-      - name: Grant Execute Permission for Gradlew
-        run: chmod +x ./gradlew
-
-      # .env 파일 생성
-      - name: Load secrets into .env file
-        run: |
-          echo "${{ secrets.ENV }}" >> .env
-
-      # Swagger API 문서화 task 실행
-      - name: Apply Swagger API Document Task
-        run: ./gradlew copyOasToSwagger
-
-      # Rest Docs API 문서화 task 실행
-      - name: Apply Rest Docs API Document Task
-        run: ./gradlew copyDocument
-
-      # Gradle 빌드
-      - name: Build with Gradle
-        id: gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: |
-            bootJar
-            --scan
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
-
-      # Dockerhub 로그인
-      - name: Login to Dockerhub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-
-      # Docker 메타데이터
-      - name: Extract Docker metadata
-        id: metadata
-        uses: docker/metadata-action@v5.5.0
-        env:
-          DOCKERHUB_IMAGE_FULL_NAME: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}
-        with:
-          images: ${{ env.DOCKERHUB_IMAGE_FULL_NAME }}
-          tags: |
-            type=sha,prefix=
-
-      # Docker 이미지 빌드, 도커허브 푸시
-      - name: Build and Push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.metadata.outputs.tags }}  # 추출된 도커 메타데이터 tags -> "${DOCKERHUB_USERNAME}/${DOCKERHUB_IMAGE_NAME}:{TAG}
-
-      # EC2 서버로 docker-compose.yml 파일 복사
-      - name: Copy docker-compose file to EC2
-        uses: burnett01/rsync-deployments@7.0.1
-        with:
-          switches: -avzr --delete
-          path: docker-compose.yml
-          remote_host: ${{ secrets.EC2_HOST }}
-          remote_user: ${{ secrets.EC2_USER }}
-          remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
-          remote_path: /home/ubuntu/
-
-      # EC2 서버로 nginx 파일 복사
-      # docker-compose.yml 에서 nginx 컨테이너 실행 시 파일을 마운트하기 위함
-      - name: Copy default.conf file to EC2
-        uses: burnett01/rsync-deployments@7.0.1
-        with:
-          switches: -avzr --delete
-          path: ./nginx
-          remote_host: ${{ secrets.EC2_HOST }}
-          remote_user: ${{ secrets.EC2_USER }}
-          remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
-          remote_path: /home/ubuntu
-
-      # EC2 배포
-      - name: Deploy to EC2 Server
-        uses: appleboy/ssh-action@v1.0.3
-        env:
-          IMAGE_FULL_PATH: ${{ steps.metadata.outputs.tags }}
-          DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME # docker-compose.yml 에서 사용할 환경 변수
-          debug: true
-          script: |
-            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-            docker compose up -d
-            docker image prune -a -f
+#name: develop push Build and Deploy
+#
+#on:
+#  push:
+#    branches: [ "develop" ]
+#
+#env:
+#  DOCKERHUB_USERNAME: fittheman
+#  DOCKERHUB_IMAGE_NAME: fittheman-server
+#
+#jobs:
+#  build-deploy:
+#    runs-on: ubuntu-latest
+#    environment: DEV
+#
+#    steps:
+#      # 체크아웃
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#
+#      # JDK 17 세팅
+#      - name: Set up JDK 17
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: '17'
+#          distribution: 'temurin'
+#
+#      # 테스트 환경에서 필요한 컨테이너 실행 (redis, postgres)
+#      - name: Run Containers
+#        run: docker compose -f ./docker-compose-test.yml up -d
+#
+#      # 테스트 환경에서 필요한 스키마, 데이터 등록
+#      - name: Apply Schema and Data
+#        env:
+#          TEST_POSTGRES_CONTAINER_NAME: "${{ github.event.repository.name }}-postgres-1"
+#          TEST_POSTGRES_USER: test
+#          TEST_POSTGRES_DB: ftm_test_db
+#        run: |
+#          echo "⏳ Waiting for postgres to be ready..."
+#          until docker exec -i $TEST_POSTGRES_CONTAINER_NAME pg_isready -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB; do
+#            echo "postgres is not ready yet. Retrying in 3 seconds..."
+#            sleep 3
+#          done
+#          echo "✅ postgres is ready!"
+#
+#          echo "${{ secrets.SCHEMA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+#          echo "${{ secrets.DATA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+#
+#      # Gradlew 실행 권한 허용
+#      - name: Grant Execute Permission for Gradlew
+#        run: chmod +x ./gradlew
+#
+#      # .env 파일 생성
+#      - name: Load secrets into .env file
+#        run: |
+#          echo "${{ secrets.ENV }}" >> .env
+#
+#      # Swagger API 문서화 task 실행
+#      - name: Apply Swagger API Document Task
+#        run: ./gradlew copyOasToSwagger
+#
+#      # Rest Docs API 문서화 task 실행
+#      - name: Apply Rest Docs API Document Task
+#        run: ./gradlew copyDocument
+#
+#      # Gradle 빌드
+#      - name: Build with Gradle
+#        id: gradle
+#        uses: gradle/gradle-build-action@v2
+#        with:
+#          arguments: |
+#            bootJar
+#            --scan
+#          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+#
+#      # Dockerhub 로그인
+#      - name: Login to Dockerhub
+#        uses: docker/login-action@v3
+#        with:
+#          username: ${{ env.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+#
+#      # Docker 메타데이터
+#      - name: Extract Docker metadata
+#        id: metadata
+#        uses: docker/metadata-action@v5.5.0
+#        env:
+#          DOCKERHUB_IMAGE_FULL_NAME: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+#        with:
+#          images: ${{ env.DOCKERHUB_IMAGE_FULL_NAME }}
+#          tags: |
+#            type=sha,prefix=
+#
+#      # Docker 이미지 빌드, 도커허브 푸시
+#      - name: Build and Push Docker image
+#        uses: docker/build-push-action@v3
+#        with:
+#          context: .
+#          push: true
+#          tags: ${{ steps.metadata.outputs.tags }}  # 추출된 도커 메타데이터 tags -> "${DOCKERHUB_USERNAME}/${DOCKERHUB_IMAGE_NAME}:{TAG}
+#
+#      # EC2 서버로 docker-compose.yml 파일 복사
+#      - name: Copy docker-compose file to EC2
+#        uses: burnett01/rsync-deployments@7.0.1
+#        with:
+#          switches: -avzr --delete
+#          path: docker-compose.yml
+#          remote_host: ${{ secrets.EC2_HOST }}
+#          remote_user: ${{ secrets.EC2_USER }}
+#          remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
+#          remote_path: /home/ubuntu/
+#
+#      # EC2 서버로 nginx 파일 복사
+#      # docker-compose.yml 에서 nginx 컨테이너 실행 시 파일을 마운트하기 위함
+#      - name: Copy default.conf file to EC2
+#        uses: burnett01/rsync-deployments@7.0.1
+#        with:
+#          switches: -avzr --delete
+#          path: ./nginx
+#          remote_host: ${{ secrets.EC2_HOST }}
+#          remote_user: ${{ secrets.EC2_USER }}
+#          remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
+#          remote_path: /home/ubuntu
+#
+#      # EC2 배포
+#      - name: Deploy to EC2 Server
+#        uses: appleboy/ssh-action@v1.0.3
+#        env:
+#          IMAGE_FULL_PATH: ${{ steps.metadata.outputs.tags }}
+#          DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}
+#        with:
+#          host: ${{ secrets.EC2_HOST }}
+#          username: ${{ secrets.EC2_USER }}
+#          key: ${{ secrets.SSH_PRIVATE_KEY }}
+#          envs: IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME # docker-compose.yml 에서 사용할 환경 변수
+#          debug: true
+#          script: |
+#            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+#            docker compose up -d
+#            docker image prune -a -f

--- a/src/main/java/com/ftm/server/gcetest/GceS3TestController.java
+++ b/src/main/java/com/ftm/server/gcetest/GceS3TestController.java
@@ -1,0 +1,34 @@
+package com.ftm.server.gcetest;
+
+import com.ftm.server.common.response.ApiResponse;
+import com.ftm.server.common.response.enums.SuccessResponseCode;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/internal/s3")
+@RequiredArgsConstructor
+public class GceS3TestController {
+
+    private final GceS3TestService gceS3TestService;
+
+    @GetMapping("/ping")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> head() {
+        Map<String, Object> result = gceS3TestService.ping();
+        return ResponseEntity.ok(ApiResponse.success(SuccessResponseCode.OK, result));
+    }
+
+    @PostMapping("/put")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> put() {
+        Map<String, Object> result = gceS3TestService.put();
+        return ResponseEntity.ok(ApiResponse.success(SuccessResponseCode.OK, result));
+    }
+
+    @PostMapping("/delete")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> delete(@RequestParam String key) {
+        Map<String, Object> result = gceS3TestService.delete(key);
+        return ResponseEntity.ok(ApiResponse.success(SuccessResponseCode.OK, result));
+    }
+}

--- a/src/main/java/com/ftm/server/gcetest/GceS3TestService.java
+++ b/src/main/java/com/ftm/server/gcetest/GceS3TestService.java
@@ -1,0 +1,69 @@
+package com.ftm.server.gcetest;
+
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GceS3TestService {
+
+    private final S3Client s3Client;
+
+    private static final String PREFIX = "healthcheck/";
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucket;
+
+    public Map<String, Object> ping() {
+        try {
+            s3Client.headObject(builder -> builder.bucket(bucket));
+        } catch (Exception ex) {
+            log.warn("S3 headObject 예외: {}", ex.getMessage(), ex);
+        }
+
+        return Map.of("ok", true, "bucket", bucket, "checkedAt", OffsetDateTime.now().toString());
+    }
+
+    public Map<String, Object> put() {
+        String objectKey = PREFIX + UUID.randomUUID() + ".txt";
+
+        PutObjectRequest req =
+                PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(objectKey)
+                        .contentType("text/plain")
+                        .build();
+
+        PutObjectResponse res = s3Client.putObject(req, RequestBody.empty());
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("ok", true);
+        result.put("bucket", bucket);
+        result.put("key", objectKey);
+        result.put("etag", res.eTag());
+        return result;
+    }
+
+    public Map<String, Object> delete(String key) {
+        String objectKey = PREFIX + key;
+        s3Client.deleteObject(builder -> builder.bucket(bucket).key(objectKey));
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("ok", true);
+        result.put("bucket", bucket);
+        result.put("key", objectKey);
+        result.put("deleted", true);
+        return result;
+    }
+}

--- a/src/main/java/com/ftm/server/infrastructure/s3/S3Config.java
+++ b/src/main/java/com/ftm/server/infrastructure/s3/S3Config.java
@@ -3,9 +3,13 @@ package com.ftm.server.infrastructure.s3;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 @Configuration
 public class S3Config {
@@ -13,13 +17,54 @@ public class S3Config {
     @Value("${aws.s3.region}")
     private String region;
 
+    @Value("${aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.sts.role-arn}")
+    private String roleArn;
+
+    @Value("${aws.sts.role-session-name}")
+    private String roleSessionName;
+
+    //    @Bean
+    //    public S3Client s3Client() {
+    //        return S3Client.builder()
+    //                .region(Region.of(region))
+    //                .credentialsProvider(
+    //                        DefaultCredentialsProvider
+    //                                .create()) // EC2에서는 자동 인식 & window&mac 에서는 환경 변수 설정 필요
+    //                .build();
+    //    }
+
     @Bean
     public S3Client s3Client() {
+        StaticCredentialsProvider baseCredentials =
+                StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+
+        StsClient sts =
+                StsClient.builder()
+                        .region(Region.of(region))
+                        .credentialsProvider(baseCredentials)
+                        .build();
+
+        StsAssumeRoleCredentialsProvider assumeRoleProvider =
+                StsAssumeRoleCredentialsProvider.builder()
+                        .stsClient(sts)
+                        .refreshRequest(
+                                AssumeRoleRequest.builder()
+                                        .roleArn(roleArn)
+                                        .roleSessionName(roleSessionName)
+                                        .build())
+                        .build();
+
+        assumeRoleProvider.resolveCredentials();
+
         return S3Client.builder()
                 .region(Region.of(region))
-                .credentialsProvider(
-                        DefaultCredentialsProvider
-                                .create()) // EC2에서는 자동 인식 & window&mac 에서는 환경 변수 설정 필요
+                .credentialsProvider(assumeRoleProvider)
                 .build();
     }
 }

--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
         "/api/posts/products"
     };
 
-    private static final String[] ANONYMOUS_MATCHERS = {"/docs/**"};
+    private static final String[] ANONYMOUS_MATCHERS = {"/docs/**", "/api/internal/s3/**"};
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/resources/application-storage.yml
+++ b/src/main/resources/application-storage.yml
@@ -15,3 +15,9 @@ aws:
       user: "users"
       post: "posts"
       product: "products"
+  sts:
+    role-arn: ${AWS_ROLE_ARN}
+    role-session-name: ftm-dev-s3
+  credentials:
+    access-key: ${AWS_ACCESS_KEY_ID}
+    secret-key: ${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #172 

## 📌 작업 내용 및 특이사항

```
AWS EC2 -> GCP GCE 이전
AWS RDS -> GCP Cloud SQL 이전
AWS S3, Cloud Front, Lamda Edge 유지
``` 

- 인프라 환경을 `AWS` -> `GCP`로 이전함에 따라 설정을 변경하고 테스트하기 위한 PR 입니다.
- GCE 배포 테스트를 위해 GCE 배포 전용 수동 워크플로우를 추가했고, 수동 배포 테스트 이후 문제가 없다면 `develop_build_deploy.yml` 워크플로우를 GCE 기반으로 리팩토링해 다시 push할 예정입니다.
- `S3` 자격증명 방법을 변경했습니다.
애플리케이션 서버와 데이터베이스 서버를 AWS EC2에서 GCP(GCE) 환경으로 이전하면서 기존 EC2 IAM 기반 S3 접근 방식은 사용할 수 없게 되었습니다.
이에 따라 S3 접근 전용 AWS IAM User/Role을 따로 생성하고,
애플리케이션에서 `Access Key` / `Secret Key`를 통해 직접 인증해 S3에 접근하도록 자격증명 방식을 변경했습니다.
GCE 서비스 계정을 활용한 OIDC 기반 접근 방식도 한번 검토했는데 구현 복잡도가 너무 높아 현재 단계에서는 적용하지 않았습니다.
- GCE 환경에서 s3 접근 테스트(head, put, delete) API를 임시로 추가했습니다.
테스트가 완료되면 추후에 삭제하겠습니다!
- `Docker Compose` 기반으로 운영하던 `Nginx/Certbot` 구성을 호스트 환경에 직접 설치해 운영하는 방식으로 전환했습니다. 
컨테이너 기반으로 운영하면 인증서 갱신과 발급 타이밍 관리가 복잡해지는 문제가 있어 단순화하기 위해서 방식을 변경했습니다.
문제 없이 완료되면 추후 프로젝트 내 Nginx 설정 파일과 docker-compose 구성 파일을 정리할 예정입니다.


## 🔍 참고사항

- GCE 전용 백엔드 도매인을 임시로 dev-api-gcp.fittheman.site 설정했습니다.
기존과 동일한 도매인으로 설정하면 certbot으로 인증서 발급하는 과정에서 문제가 발생했습니다.
추후 GCE로 완전히 이전이 되면 기존 도메인으로 변경하겠습니다.
- 배포가 성공적으로 완료되면, GCE 환경에서 AWS S3 접근이 정상적으로 동작하는지 테스트해보겠습니다.
- 이후 테스트까지 문제없이 완료되면, GCE 기반의 설정으로 모두 리팩토링 진행하겠습니다.

## 📚 기타

-