### PR TITLE
chore: GCE 배포 테스트 설정 (#175)

### DIFF
--- a/.github/workflows/develop-build-deploy-gce-manual.yml
+++ b/.github/workflows/develop-build-deploy-gce-manual.yml
@@ -1,0 +1,123 @@
+name: develop push Build and Deploy (GCE)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "배포할 브랜치 (수동 테스트 전용)"
+        required: true
+        default: "chore/#169"
+
+env:
+  DOCKERHUB_USERNAME: fittheman
+  DOCKERHUB_IMAGE_NAME: fittheman-server
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    environment: DEV
+
+    steps:
+      # 체크아웃
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      # JDK 17 세팅
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # 테스트 환경에서 필요한 컨테이너 실행 (redis, postgres)
+      - name: Run Containers
+        run: docker compose -f ./docker-compose-test.yml up -d
+
+      # 테스트 환경에서 필요한 스키마, 데이터 등록
+      - name: Apply Schema and Data
+        env:
+          TEST_POSTGRES_CONTAINER_NAME: "${{ github.event.repository.name }}-postgres-1"
+          TEST_POSTGRES_USER: test
+          TEST_POSTGRES_DB: ftm_test_db
+        run: |
+          echo "⏳ Waiting for postgres to be ready..."
+          until docker exec -i $TEST_POSTGRES_CONTAINER_NAME pg_isready -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB; do
+            echo "postgres is not ready yet. Retrying in 3 seconds..."
+            sleep 3
+          done
+          echo "✅ postgres is ready!"
+
+          echo "${{ secrets.SCHEMA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+          echo "${{ secrets.DATA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+
+      # Gradlew 실행 권한 허용
+      - name: Grant Execute Permission for Gradlew
+        run: chmod +x ./gradlew
+
+      # .env 파일 생성
+      - name: Load secrets into .env file
+        run: |
+          echo "${{ secrets.ENV }}" >> .env
+
+      # Swagger API 문서화 task 실행
+      - name: Apply Swagger API Document Task
+        run: ./gradlew copyOasToSwagger
+
+      # Rest Docs API 문서화 task 실행
+      - name: Apply Rest Docs API Document Task
+        run: ./gradlew copyDocument
+
+      # Gradle 빌드
+      - name: Build with Gradle
+        id: gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            bootJar
+            --scan
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+      # Dockerhub 로그인
+      - name: Login to Dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      # Docker 메타데이터
+      - name: Extract Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v5.5.0
+        env:
+          DOCKERHUB_IMAGE_FULL_NAME: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE_FULL_NAME }}
+          tags: |
+            type=sha,prefix=
+
+      # Docker 이미지 빌드, 도커허브 푸시
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}  # 추출된 도커 메타데이터 tags -> "${DOCKERHUB_USERNAME}/${DOCKERHUB_IMAGE_NAME}:{TAG}
+
+      # GCE 배포
+      - name: Deploy to GCE Server
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          IMAGE_FULL_PATH: ${{ steps.metadata.outputs.tags }}
+          DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}
+        with:
+          host: ${{ secrets.GCE_HOST }}
+          username: ${{ secrets.GCE_USER }}
+          key: ${{ secrets.GCE_SSH_PRIVATE_KEY }}
+          envs: IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME # docker-compose.yml 에서 사용할 환경 변수
+          debug: true
+          script: |
+            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+            docker compose up -d
+            docker image prune -a -f

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -1,140 +1,140 @@
-name: develop push Build and Deploy
-
-on:
-  push:
-    branches: [ "develop" ]
-
-env:
-  DOCKERHUB_USERNAME: fittheman
-  DOCKERHUB_IMAGE_NAME: fittheman-server
-
-jobs:
-  build-deploy:
-    runs-on: ubuntu-latest
-    environment: DEV
-
-    steps:
-      # 체크아웃
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # JDK 17 세팅
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      # 테스트 환경에서 필요한 컨테이너 실행 (redis, postgres)
-      - name: Run Containers
-        run: docker compose -f ./docker-compose-test.yml up -d
-
-      # 테스트 환경에서 필요한 스키마, 데이터 등록
-      - name: Apply Schema and Data
-        env:
-          TEST_POSTGRES_CONTAINER_NAME: "${{ github.event.repository.name }}-postgres-1"
-          TEST_POSTGRES_USER: test
-          TEST_POSTGRES_DB: ftm_test_db
-        run: |
-          echo "⏳ Waiting for postgres to be ready..."
-          until docker exec -i $TEST_POSTGRES_CONTAINER_NAME pg_isready -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB; do
-            echo "postgres is not ready yet. Retrying in 3 seconds..."
-            sleep 3
-          done
-          echo "✅ postgres is ready!"
-
-          echo "${{ secrets.SCHEMA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
-          echo "${{ secrets.DATA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
-
-      # Gradlew 실행 권한 허용
-      - name: Grant Execute Permission for Gradlew
-        run: chmod +x ./gradlew
-
-      # .env 파일 생성
-      - name: Load secrets into .env file
-        run: |
-          echo "${{ secrets.ENV }}" >> .env
-
-      # Swagger API 문서화 task 실행
-      - name: Apply Swagger API Document Task
-        run: ./gradlew copyOasToSwagger
-
-      # Rest Docs API 문서화 task 실행
-      - name: Apply Rest Docs API Document Task
-        run: ./gradlew copyDocument
-
-      # Gradle 빌드
-      - name: Build with Gradle
-        id: gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: |
-            bootJar
-            --scan
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
-
-      # Dockerhub 로그인
-      - name: Login to Dockerhub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-
-      # Docker 메타데이터
-      - name: Extract Docker metadata
-        id: metadata
-        uses: docker/metadata-action@v5.5.0
-        env:
-          DOCKERHUB_IMAGE_FULL_NAME: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}
-        with:
-          images: ${{ env.DOCKERHUB_IMAGE_FULL_NAME }}
-          tags: |
-            type=sha,prefix=
-
-      # Docker 이미지 빌드, 도커허브 푸시
-      - name: Build and Push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.metadata.outputs.tags }}  # 추출된 도커 메타데이터 tags -> "${DOCKERHUB_USERNAME}/${DOCKERHUB_IMAGE_NAME}:{TAG}
-
-      # EC2 서버로 docker-compose.yml 파일 복사
-      - name: Copy docker-compose file to EC2
-        uses: burnett01/rsync-deployments@7.0.1
-        with:
-          switches: -avzr --delete
-          path: docker-compose.yml
-          remote_host: ${{ secrets.EC2_HOST }}
-          remote_user: ${{ secrets.EC2_USER }}
-          remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
-          remote_path: /home/ubuntu/
-
-      # EC2 서버로 nginx 파일 복사
-      # docker-compose.yml 에서 nginx 컨테이너 실행 시 파일을 마운트하기 위함
-      - name: Copy default.conf file to EC2
-        uses: burnett01/rsync-deployments@7.0.1
-        with:
-          switches: -avzr --delete
-          path: ./nginx
-          remote_host: ${{ secrets.EC2_HOST }}
-          remote_user: ${{ secrets.EC2_USER }}
-          remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
-          remote_path: /home/ubuntu
-
-      # EC2 배포
-      - name: Deploy to EC2 Server
-        uses: appleboy/ssh-action@v1.0.3
-        env:
-          IMAGE_FULL_PATH: ${{ steps.metadata.outputs.tags }}
-          DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME # docker-compose.yml 에서 사용할 환경 변수
-          debug: true
-          script: |
-            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-            docker compose up -d
-            docker image prune -a -f
+#name: develop push Build and Deploy
+#
+#on:
+#  push:
+#    branches: [ "develop" ]
+#
+#env:
+#  DOCKERHUB_USERNAME: fittheman
+#  DOCKERHUB_IMAGE_NAME: fittheman-server
+#
+#jobs:
+#  build-deploy:
+#    runs-on: ubuntu-latest
+#    environment: DEV
+#
+#    steps:
+#      # 체크아웃
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#
+#      # JDK 17 세팅
+#      - name: Set up JDK 17
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: '17'
+#          distribution: 'temurin'
+#
+#      # 테스트 환경에서 필요한 컨테이너 실행 (redis, postgres)
+#      - name: Run Containers
+#        run: docker compose -f ./docker-compose-test.yml up -d
+#
+#      # 테스트 환경에서 필요한 스키마, 데이터 등록
+#      - name: Apply Schema and Data
+#        env:
+#          TEST_POSTGRES_CONTAINER_NAME: "${{ github.event.repository.name }}-postgres-1"
+#          TEST_POSTGRES_USER: test
+#          TEST_POSTGRES_DB: ftm_test_db
+#        run: |
+#          echo "⏳ Waiting for postgres to be ready..."
+#          until docker exec -i $TEST_POSTGRES_CONTAINER_NAME pg_isready -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB; do
+#            echo "postgres is not ready yet. Retrying in 3 seconds..."
+#            sleep 3
+#          done
+#          echo "✅ postgres is ready!"
+#
+#          echo "${{ secrets.SCHEMA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+#          echo "${{ secrets.DATA_SQL }}" | docker exec -i $TEST_POSTGRES_CONTAINER_NAME psql -U $TEST_POSTGRES_USER -d $TEST_POSTGRES_DB
+#
+#      # Gradlew 실행 권한 허용
+#      - name: Grant Execute Permission for Gradlew
+#        run: chmod +x ./gradlew
+#
+#      # .env 파일 생성
+#      - name: Load secrets into .env file
+#        run: |
+#          echo "${{ secrets.ENV }}" >> .env
+#
+#      # Swagger API 문서화 task 실행
+#      - name: Apply Swagger API Document Task
+#        run: ./gradlew copyOasToSwagger
+#
+#      # Rest Docs API 문서화 task 실행
+#      - name: Apply Rest Docs API Document Task
+#        run: ./gradlew copyDocument
+#
+#      # Gradle 빌드
+#      - name: Build with Gradle
+#        id: gradle
+#        uses: gradle/gradle-build-action@v2
+#        with:
+#          arguments: |
+#            bootJar
+#            --scan
+#          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+#
+#      # Dockerhub 로그인
+#      - name: Login to Dockerhub
+#        uses: docker/login-action@v3
+#        with:
+#          username: ${{ env.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+#
+#      # Docker 메타데이터
+#      - name: Extract Docker metadata
+#        id: metadata
+#        uses: docker/metadata-action@v5.5.0
+#        env:
+#          DOCKERHUB_IMAGE_FULL_NAME: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}
+#        with:
+#          images: ${{ env.DOCKERHUB_IMAGE_FULL_NAME }}
+#          tags: |
+#            type=sha,prefix=
+#
+#      # Docker 이미지 빌드, 도커허브 푸시
+#      - name: Build and Push Docker image
+#        uses: docker/build-push-action@v3
+#        with:
+#          context: .
+#          push: true
+#          tags: ${{ steps.metadata.outputs.tags }}  # 추출된 도커 메타데이터 tags -> "${DOCKERHUB_USERNAME}/${DOCKERHUB_IMAGE_NAME}:{TAG}
+#
+#      # EC2 서버로 docker-compose.yml 파일 복사
+#      - name: Copy docker-compose file to EC2
+#        uses: burnett01/rsync-deployments@7.0.1
+#        with:
+#          switches: -avzr --delete
+#          path: docker-compose.yml
+#          remote_host: ${{ secrets.EC2_HOST }}
+#          remote_user: ${{ secrets.EC2_USER }}
+#          remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
+#          remote_path: /home/ubuntu/
+#
+#      # EC2 서버로 nginx 파일 복사
+#      # docker-compose.yml 에서 nginx 컨테이너 실행 시 파일을 마운트하기 위함
+#      - name: Copy default.conf file to EC2
+#        uses: burnett01/rsync-deployments@7.0.1
+#        with:
+#          switches: -avzr --delete
+#          path: ./nginx
+#          remote_host: ${{ secrets.EC2_HOST }}
+#          remote_user: ${{ secrets.EC2_USER }}
+#          remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
+#          remote_path: /home/ubuntu
+#
+#      # EC2 배포
+#      - name: Deploy to EC2 Server
+#        uses: appleboy/ssh-action@v1.0.3
+#        env:
+#          IMAGE_FULL_PATH: ${{ steps.metadata.outputs.tags }}
+#          DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}
+#        with:
+#          host: ${{ secrets.EC2_HOST }}
+#          username: ${{ secrets.EC2_USER }}
+#          key: ${{ secrets.SSH_PRIVATE_KEY }}
+#          envs: IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME # docker-compose.yml 에서 사용할 환경 변수
+#          debug: true
+#          script: |
+#            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+#            docker compose up -d
+#            docker image prune -a -f


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #175 

## 📌 작업 내용 및 특이사항
- GCE 배포 테스트를 위한 PR 입니다.
GCP로 인프라 환경을 완전 이전하기 전, 자동화 배포 테스트를 위해 GCE 전용 배포 워크플로우를 추가했습니다. (수동 트리거)
- 원활한 테스트를 위해 기존 EC2 배포 워크플로우는 주석처리해두었습니다.
- GCE 배포 테스트가 정상적으로 완료되면,
PR(#174)에서 해당 워크플로우를 메인 배포 워크플로우로 리팩토링하는 작업까지 반영하도록 하겠습니다.

## 🔍 참고사항

-

## 📚 기타

-