### PR TITLE
chore: 빌드 및 배포 워크플로우 체크아웃 설정 변경 (#177)

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -17,8 +17,6 @@ jobs:
       # 체크아웃
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
 
       # JDK 17 세팅
       - name: Set up JDK 17


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #177

## 📌 작업 내용 및 특이사항

- 수동 배포 테스트에서 사용했던 체크아웃 임시 설정이 남아있어 제거했습니다.
그냥 두어도 문제가 되지는 않지만 헷갈림을 방지하고 명확하게 하기 위해서 제거했습니다.
- `develop_build_deploy.yml `의 체크아웃 스텝에서 with 설정을 제거했습니다.

## 🔍 참고사항

-

## 📚 기타

-