### PR TITLE
fix : 해시태그 기반 상품 조회 시 매칭되는 상품 없을 때 에러 발생하는 상황 수정

### DIFF
--- a/src/main/java/com/ftm/server/application/service/post/LoadProductsByHashTagService.java
+++ b/src/main/java/com/ftm/server/application/service/post/LoadProductsByHashTagService.java
@@ -44,7 +44,7 @@ public class LoadProductsByHashTagService implements LoadProductsByHashTagUseCas
                     productIdAndScoreList.stream().filter(a -> a.getScore() < score).toList();
         }
 
-        if (productIdAndScoreList.size() == 0) {
+        if (productIdAndScoreList.isEmpty()) {
             return LoadProductsByHashTagVoWrapper.of(List.of(), false, 0.0);
         }
 
@@ -56,6 +56,10 @@ public class LoadProductsByHashTagService implements LoadProductsByHashTagUseCas
             postProducts =
                     loadPostProductPort.loadPostProductsByHashTags(
                             new FindByProductHashTagsQuery(hashtagList));
+        }
+
+        if (postProducts.isEmpty()) {
+            return LoadProductsByHashTagVoWrapper.of(List.of(), false, 0.0);
         }
 
         Map<Long, PostProduct> postProductMap =
@@ -70,6 +74,8 @@ public class LoadProductsByHashTagService implements LoadProductsByHashTagUseCas
         int beforeSize = productIdAndScoreList.size();
         Set<Long> tempProductIds =
                 postProducts.stream().map(PostProduct::getId).collect(Collectors.toSet());
+
+        // 캐시에 존재하는 상품 중(인기순으로 정렬되어 있음), 해시태그와 관련 있는 상품만 조회 + limit 만큼 자르기
         List<ProductIdAndScoreVo> productIdAndScoreVoList =
                 productIdAndScoreList.stream()
                         .filter(vo -> tempProductIds.contains(vo.getProductId())) // DB에 존재하는 상품만
@@ -96,7 +102,8 @@ public class LoadProductsByHashTagService implements LoadProductsByHashTagUseCas
                 loadProductAndUserLikeVos.stream()
                         .collect(
                                 Collectors.toMap(
-                                        LoadProductAndUserLikeVo::getProductId, // key: productId
+                                        LoadProductAndUserLikeVo::getProductId, // key:
+                                        // productId
                                         Function.identity() // value: 해당 PostProduct 객체 자체
                                         ));
 


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #

## 📌 작업 내용 및 특이사항

- 해시태그 기반 상품 조회 시, 해시태그와 매칭되는 상품이 없을 때 exception 발생하는 상황을 수정했습니다.

## 🔍 참고사항

-

## 📚 기타

-