### PR TITLE
refactor: 게시글 상세 조회 API 리팩토링 (#184)

### DIFF
--- a/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/LoadPostDetailResponse.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/post/dto/response/LoadPostDetailResponse.java
@@ -19,6 +19,7 @@ public class LoadPostDetailResponse {
     private final Integer viewCount;
     private final Integer likeCount;
     private final Boolean userLikeYn;
+    private final Boolean userBookmarkYn;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING)
     private final LocalDateTime createdAt;
@@ -50,6 +51,7 @@ public class LoadPostDetailResponse {
         this.postProducts =
                 postDetailVo.getProducts().stream().map(PostProductResponse::from).toList();
         this.userLikeYn = postDetailVo.getUserLikeYn();
+        this.userBookmarkYn = postDetailVo.getUserBookmarkYn();
     }
 
     public static LoadPostDetailResponse from(PostDetailVo postDetailVo) {

--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
@@ -43,7 +43,8 @@ public class PostDomainPersistenceAdapter
                 DeleteProductLikePort,
                 LoadPostLikePort,
                 SavePostLikePort,
-                DeletePostLikePort {
+                DeletePostLikePort,
+                LoadBookmarkForPostPort {
 
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
@@ -53,6 +54,7 @@ public class PostDomainPersistenceAdapter
     private final UserImageRepository userImageRepository;
     private final ProductLikeRepository productLikeRepository;
     private final PostLikeRepository postLikeRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     private final PostMapper postMapper;
     private final PostImageMapper postImageMapper;
@@ -183,6 +185,11 @@ public class PostDomainPersistenceAdapter
                                         e.getBookmarkYn(),
                                         postMapper.toDomainEntity((PostJpaEntity) e.getData())))
                 .toList();
+    }
+
+    @Override
+    public Boolean existsBookmarkByUserIdAndPostId(FindBookmarkByUserIdAndPostIdQuery query) {
+        return bookmarkRepository.existsByUserIdAndPostId(query.getUserId(), query.getPostId());
     }
 
     @Override

--- a/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadBookmarkForPostPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/persistence/post/LoadBookmarkForPostPort.java
@@ -1,0 +1,7 @@
+package com.ftm.server.application.port.out.persistence.post;
+
+import com.ftm.server.application.query.FindBookmarkByUserIdAndPostIdQuery;
+
+public interface LoadBookmarkForPostPort {
+    Boolean existsBookmarkByUserIdAndPostId(FindBookmarkByUserIdAndPostIdQuery query);
+}

--- a/src/main/java/com/ftm/server/application/service/post/LoadPostDetailService.java
+++ b/src/main/java/com/ftm/server/application/service/post/LoadPostDetailService.java
@@ -7,8 +7,10 @@ import com.ftm.server.application.vo.post.PostDetailVo;
 import com.ftm.server.common.exception.CustomException;
 import com.ftm.server.common.response.enums.ErrorResponseCode;
 import com.ftm.server.domain.entity.*;
+import com.ftm.server.domain.enums.UserRole;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,7 @@ public class LoadPostDetailService implements LoadPostDetailUseCase {
     private final LoadUserImageForPostPort loadUserImageForPostPort;
     private final UpdatePostPort updatePostPort;
     private final LoadPostLikePort loadPostLikePort;
+    private final LoadBookmarkForPostPort loadBookmarkForPostPort;
 
     @Override
     @Transactional
@@ -50,12 +53,17 @@ public class LoadPostDetailService implements LoadPostDetailUseCase {
                         .loadUserById(FindByIdQuery.of(post.getUserId()))
                         .orElseThrow(() -> CustomException.USER_NOT_FOUND);
 
-        // 유저 이미지 조회
+        // 유저 이미지 조회 (SYSTEM 유저 -> default image)
+        Optional<UserImage> userImageOpt =
+                loadUserImageForPostPort.loadUserImageByUserId(FindByUserIdQuery.of(user.getId()));
         UserImage userImage =
-                loadUserImageForPostPort
-                        .loadUserImageByUserId(FindByUserIdQuery.of(user.getId()))
-                        .orElseThrow(
-                                () -> new CustomException(ErrorResponseCode.USER_IMAGE_NOT_FOUND));
+                userImageOpt.orElseGet(
+                        () -> {
+                            if (user.getRole() == UserRole.SYSTEM) {
+                                return UserImage.defaultForSystem(user.getId());
+                            }
+                            throw new CustomException(ErrorResponseCode.USER_IMAGE_NOT_FOUND);
+                        });
 
         // 게시글 이미지 목록 조회
         List<PostImage> postImages =
@@ -70,18 +78,31 @@ public class LoadPostDetailService implements LoadPostDetailUseCase {
                 loadPostProductImagePort.loadPostProductImagesByPostProductIds(
                         FindByIdsQuery.from(
                                 postProducts.stream().map(PostProduct::getId).toList()));
-
         Map<Long, PostProductImage> postProductImageMap =
                 postProductImages.stream()
                         .collect(
                                 Collectors.toMap(
                                         PostProductImage::getPostProductId, Function.identity()));
 
+        // 유저 게시글 좋아요 여부
         Boolean userLikeYn =
                 userId != null
                         && loadPostLikePort.findPostLikeByUser(userId, query.getId()).getLikeYn();
 
+        // 북마크 여부
+        Boolean bookmarkYn =
+                userId != null
+                        && loadBookmarkForPostPort.existsBookmarkByUserIdAndPostId(
+                                FindBookmarkByUserIdAndPostIdQuery.of(user.getId(), post.getId()));
+
         return PostDetailVo.from(
-                post, user, userImage, postImages, postProducts, postProductImageMap, userLikeYn);
+                post,
+                user,
+                userImage,
+                postImages,
+                postProducts,
+                postProductImageMap,
+                userLikeYn,
+                bookmarkYn);
     }
 }

--- a/src/main/java/com/ftm/server/application/vo/post/PostDetailVo.java
+++ b/src/main/java/com/ftm/server/application/vo/post/PostDetailVo.java
@@ -23,6 +23,7 @@ public class PostDetailVo {
     private final List<PostImage> postImages;
     private final List<PostProductDetailVo> products;
     private final Boolean userLikeYn;
+    private final Boolean userBookmarkYn;
 
     private PostDetailVo(
             Post post,
@@ -30,7 +31,8 @@ public class PostDetailVo {
             UserImage userImage,
             List<PostImage> postImages,
             List<PostProductDetailVo> products,
-            Boolean userLikeYn) {
+            Boolean userLikeYn,
+            Boolean userBookmarkYn) {
         this.postId = post.getId();
         this.title = post.getTitle();
         this.content = post.getContent();
@@ -44,6 +46,7 @@ public class PostDetailVo {
         this.postImages = postImages;
         this.products = products;
         this.userLikeYn = userLikeYn;
+        this.userBookmarkYn = userBookmarkYn;
     }
 
     public static PostDetailVo from(
@@ -53,13 +56,15 @@ public class PostDetailVo {
             List<PostImage> postImages,
             List<PostProduct> postProducts,
             Map<Long, PostProductImage> postProductImageMap,
-            Boolean userLikeYn) {
+            Boolean userLikeYn,
+            Boolean userBookmarkYn) {
         return new PostDetailVo(
                 post,
                 user,
                 userImage,
                 postImages,
                 PostProductDetailVo.listFrom(postProducts, postProductImageMap),
-                userLikeYn);
+                userLikeYn,
+                userBookmarkYn);
     }
 }

--- a/src/main/java/com/ftm/server/domain/entity/UserImage.java
+++ b/src/main/java/com/ftm/server/domain/entity/UserImage.java
@@ -51,6 +51,10 @@ public class UserImage extends BaseTime {
                 .build();
     }
 
+    public static UserImage defaultForSystem(Long userId) {
+        return createUserImage(userId);
+    }
+
     public void updateDefaultUserImage() {
         this.objectKey = PropertiesHolder.USER_DEFAULT_IMAGE;
     }

--- a/src/test/java/com/ftm/server/post/LoadPostDetailTest.java
+++ b/src/test/java/com/ftm/server/post/LoadPostDetailTest.java
@@ -66,6 +66,9 @@ public class LoadPostDetailTest extends BaseTest {
                     fieldWithPath("data.viewCount").type(NUMBER).description("게시글 조회수"),
                     fieldWithPath("data.likeCount").type(NUMBER).description("게시글 좋아요 수"),
                     fieldWithPath("data.userLikeYn").type(BOOLEAN).description("사용자 게시글 좋아요 여부"),
+                    fieldWithPath("data.userBookmarkYn")
+                            .type(BOOLEAN)
+                            .description("사용자 게시글 북마크 여부"),
                     fieldWithPath("data.createdAt").type(STRING).description("게시글 생성 날짜"),
                     fieldWithPath("data.updatedAt").type(STRING).description("게시글 수정 날짜"),
                     fieldWithPath("data.postImages[]").type(ARRAY).description("게시글 이미지 목록 정보"),


### PR DESCRIPTION
* refactor: 게시글 작성자 ROLE에 따른 이미지 처리 로직 리팩토링
* refactor: 응답 데이터에 userBookmarkYn(사용자 게시글 좋아요 여부) 필드 추가
* test: 게시글 상세 조회 API 테스트 리팩토링

## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #184 

## 📌 작업 내용 및 특이사항

- 유저픽 게시글 상세 조회에서 작성자가 `SYSTEM` 유저일 경우, 해당 유저의 프로필 이미지가 없어 예외가 발생하는 문제를 해결했습니다.
- 애플리케이션 레벨에서 작성자의 `UserRole`를 확인해 `SYSTEM` 유저일 경우 default UserImage를 생성하도록 리팩토링했습니다.
- 더 안정적으로 유지하기 위해 DB 마이그레이션으로 `SYSTEM` 유저 전용 `UserImage` row를 추가했습니다.
로컬 환경에서도 동일하게 적용하면 좋을 것 같아요. 노션에 작성해놓겠습니다.
- 유저픽 게시글 상세 조회 API 응답 데이터에 `userBookmarkYn` 필드를 추가했습니다.
이 필드는 작성자가 아닌 요청한 사용자의 해당 유저픽 게시글 북마크 여부 필드입니다.
- 테스트 코드도 변경된 부분을 리팩토링했습니다.

## 🔍 참고사항

-

## 📚 기타

-