### PR TITLE
refactor: 백엔드 도메인 이전에 따른 리팩토링 (#187)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,8 +96,7 @@ tasks.named('test') {
 openapi3 {
     servers = [
             { url = "http://localhost:8080/" },
-            { url = "https://dev-api.fittheman.site/" },
-            { url = "https://dev-api-gcp.fittheman.site/" }
+            { url = "https://dev-api.fittheman.store/" }
     ]
     title = '핏더맨 API DOCUMENT'
     description = '핏더맨 api 명세서입니다.'


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #187 

## 📌 작업 내용 및 특이사항

- 기존 백엔드 도메인 기간이 2026년 2월 6일부로 만료되서 새로운 도메인을 발급하고 이전했습니다.
새로운 백엔드 도메인 주소는 노션에 적어두겠습니다.
- 배포된 서버에서 기존 도메인 인증서를 삭제하고 새로운 도메인의 인증서를 발급받고 Nginx 설정을 수정했습니다.
- Github Actions Secrets VM 호스트 정보도 함께 수정했습니다.
- build.gradle Swagger 설정 dev 백엔드 주소를 새로운 주소로 변경했습니다.

## 🔍 참고사항

-

## 📚 기타

-