### PR TITLE
feature : 게시글 상세 조회 시 상품 목록 조회 순서를 id 순으로 설정

### DIFF
--- a/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/adapter/post/PostDomainPersistenceAdapter.java
@@ -235,6 +235,7 @@ public class PostDomainPersistenceAdapter
                         .orElseThrow(() -> new CustomException(ErrorResponseCode.POST_NOT_FOUND));
 
         return postProductRepository.findAllByPost(postJpaEntity).stream()
+                .sorted((a, b) -> Math.toIntExact(a.getId() - b.getId()))
                 .map(postProductMapper::toDomainEntity)
                 .toList();
     }


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #189

## 📌 작업 내용 및 특이사항

- 게시글 상세 조회 시, 상품 목록들이 id 순으로 조회되도록 변경했습니다.

## 🔍 참고사항

-

## 📚 기타

-