### PR TITLE
fix : soft-delete된 게시글이 캐시 기반 랭킹 API에 노출되는 버그 수정

### DIFF
--- a/src/main/java/com/ftm/server/adapter/out/cache/EvictPostCachesAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/cache/EvictPostCachesAdapter.java
@@ -1,0 +1,50 @@
+package com.ftm.server.adapter.out.cache;
+
+import static com.ftm.server.common.consts.StaticConsts.*;
+
+import com.ftm.server.application.port.out.cache.EvictPostCachesPort;
+import com.ftm.server.common.annotation.Adapter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.CacheManager;
+
+@Adapter
+public class EvictPostCachesAdapter implements EvictPostCachesPort {
+
+    private final CacheManager defaultCacheManager;
+    private final CacheManager trendingPostsCacheManager;
+    private final CacheManager userPickPopularPostsCacheManager;
+    private final CacheManager userPickTopBookmarkPostsCacheManager;
+    private final CacheManager userPickAllPopularPostsCacheManager;
+
+    public EvictPostCachesAdapter(
+            CacheManager defaultCacheManager,
+            @Qualifier("trendingPostsCacheManager") CacheManager trendingPostsCacheManager,
+            @Qualifier("userPickPopularPostsCacheManager")
+                    CacheManager userPickPopularPostsCacheManager,
+            @Qualifier("userPickTopBookmarkPostsCacheManager")
+                    CacheManager userPickTopBookmarkPostsCacheManager,
+            @Qualifier("userPickAllPopularPostsCacheManager")
+                    CacheManager userPickAllPopularPostsCacheManager) {
+        this.defaultCacheManager = defaultCacheManager;
+        this.trendingPostsCacheManager = trendingPostsCacheManager;
+        this.userPickPopularPostsCacheManager = userPickPopularPostsCacheManager;
+        this.userPickTopBookmarkPostsCacheManager = userPickTopBookmarkPostsCacheManager;
+        this.userPickAllPopularPostsCacheManager = userPickAllPopularPostsCacheManager;
+    }
+
+    @Override
+    public void evictAllPostRankingCaches() {
+        evict(defaultCacheManager, USER_PICK_BIBLE_POSTS_CACHE_NAME);
+        evict(trendingPostsCacheManager, TRENDING_POSTS_CACHE_NAME);
+        evict(userPickPopularPostsCacheManager, USER_PICK_POPULAR_POSTS_CACHE_NAME);
+        evict(userPickTopBookmarkPostsCacheManager, USER_PICK_TOP_BOOKMARK_POSTS_CACHE_NAME);
+        evict(userPickAllPopularPostsCacheManager, USER_PICK_STORY_POPULAR_POSTS_CACHE_NAME);
+    }
+
+    private void evict(CacheManager manager, String cacheName) {
+        var cache = manager.getCache(cacheName);
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+}

--- a/src/main/java/com/ftm/server/adapter/out/cache/LoadTrendingManWithCacheAdapter.java
+++ b/src/main/java/com/ftm/server/adapter/out/cache/LoadTrendingManWithCacheAdapter.java
@@ -71,7 +71,8 @@ public class LoadTrendingManWithCacheAdapter implements LoadTrendingManWithCache
         userIds.forEach(p -> imageMap.put(p, null));
         loadUserImagePort
                 .loadUserImagesByUserIdIn(FindUserImagesByIdsQuery.of(userIds))
-                .forEach(userImage -> imageMap.put(userImage.getId(), userImage.getObjectKey()));
+                .forEach(
+                        userImage -> imageMap.put(userImage.getUserId(), userImage.getObjectKey()));
 
         // 4. 결과 조합 (순위 부여)
         return IntStream.range(0, topN.size())

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostRepository.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostRepository.java
@@ -31,6 +31,7 @@ public interface PostRepository
         SELECT id
         FROM post p
         WHERE p.created_at >= :since
+          AND p.is_deleted = false
         ORDER BY
         (p.like_count / NULLIF(MAX(p.like_count) OVER (), 0.0)
         + p.view_count / NULLIF(MAX(p.view_count) OVER (), 0.0)) DESC ,
@@ -41,7 +42,8 @@ public interface PostRepository
     List<Long> findTopNPostsByViewCountAndLikeCount(
             @Param("since") LocalDateTime since, @Param("limit") int limit);
 
-    @Query("select p.id from PostJpaEntity p order by p.likeCount DESC")
+    @Query(
+            "select p.id from PostJpaEntity p where p.isDeleted = false order by p.likeCount DESC limit :limit")
     List<Long> findTopNPostsByLikeCount(@Param("limit") int limit);
 
     @Query(

--- a/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepositoryImpl.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/repository/PostWithBookmarkCustomRepositoryImpl.java
@@ -104,6 +104,7 @@ public class PostWithBookmarkCustomRepositoryImpl implements PostWithBookmarkCus
                                 ))
                 .from(postJpaEntity)
                 .where(postJpaEntity.id.in(query.getIds()))
+                .where(postJpaEntity.isDeleted.eq(false))
                 .leftJoin(bookmarkJpaEntity)
                 .on(bookmarkJpaEntity.post.id.eq(postJpaEntity.id))
                 .groupBy(
@@ -139,13 +140,19 @@ public class PostWithBookmarkCustomRepositoryImpl implements PostWithBookmarkCus
                 queryFactory
                         .select(postJpaEntity.likeCount.max(), postJpaEntity.viewCount.max())
                         .from(postJpaEntity)
+                        .where(postJpaEntity.isDeleted.eq(false))
                         .fetchOne();
 
         int maxLike = maxValues.get(postJpaEntity.likeCount.max());
         int maxView = maxValues.get(postJpaEntity.viewCount.max());
 
         List<UserPickPopularPostCursorVo> result =
-                queryFactory.select(postJpaEntity).from(postJpaEntity).fetch().stream()
+                queryFactory
+                        .select(postJpaEntity)
+                        .from(postJpaEntity)
+                        .where(postJpaEntity.isDeleted.eq(false))
+                        .fetch()
+                        .stream()
                         .map(
                                 vo -> {
                                     double normLike =

--- a/src/main/java/com/ftm/server/application/port/out/cache/EvictPostCachesPort.java
+++ b/src/main/java/com/ftm/server/application/port/out/cache/EvictPostCachesPort.java
@@ -1,0 +1,8 @@
+package com.ftm.server.application.port.out.cache;
+
+import com.ftm.server.common.annotation.Port;
+
+@Port
+public interface EvictPostCachesPort {
+    void evictAllPostRankingCaches();
+}

--- a/src/main/java/com/ftm/server/application/service/post/DeletePostService.java
+++ b/src/main/java/com/ftm/server/application/service/post/DeletePostService.java
@@ -2,8 +2,10 @@ package com.ftm.server.application.service.post;
 
 import com.ftm.server.application.command.post.DeletePostCommand;
 import com.ftm.server.application.port.in.post.DeletePostUseCase;
+import com.ftm.server.application.port.out.cache.EvictPostCachesPort;
 import com.ftm.server.application.port.out.persistence.post.LoadPostPort;
 import com.ftm.server.application.port.out.persistence.post.UpdatePostPort;
+import com.ftm.server.application.port.out.transcation.AfterCommitExecutorPort;
 import com.ftm.server.application.query.FindByIdQuery;
 import com.ftm.server.common.exception.CustomException;
 import com.ftm.server.common.response.enums.ErrorResponseCode;
@@ -19,6 +21,8 @@ public class DeletePostService implements DeletePostUseCase {
 
     private final LoadPostPort loadPostPort;
     private final UpdatePostPort updatePostPort;
+    private final EvictPostCachesPort evictPostCachesPort;
+    private final AfterCommitExecutorPort afterCommitExecutorPort;
 
     @Override
     @Transactional
@@ -29,10 +33,12 @@ public class DeletePostService implements DeletePostUseCase {
                         .orElseThrow(() -> new CustomException(ErrorResponseCode.POST_NOT_FOUND));
         post.validateWriter(command.getUserId());
 
-        // 게시글 삭제 필드 업데이트
         post.updateIsDeleted(true);
         post.updateDeletedAt(LocalDateTime.now());
 
         updatePostPort.updatePost(post);
+
+        // DB 커밋 이후 캐시 무효화 (커밋 전 evict 시 재구성 타이밍 문제 방지)
+        afterCommitExecutorPort.doAfterCommit(evictPostCachesPort::evictAllPostRankingCaches);
     }
 }

--- a/src/main/java/com/ftm/server/application/service/post/GetUserPickAllPostsService.java
+++ b/src/main/java/com/ftm/server/application/service/post/GetUserPickAllPostsService.java
@@ -161,6 +161,7 @@ public class GetUserPickAllPostsService implements GetUserPickPostsUseCase {
                                         (a, b) -> a));
 
         return posts.stream()
+                .filter(b -> postDetailMap.containsKey(b.getPostId()))
                 .map(
                         b -> {
                             PostWithUserAndBookmarkCountVo post = postDetailMap.get(b.getPostId());
@@ -200,6 +201,7 @@ public class GetUserPickAllPostsService implements GetUserPickPostsUseCase {
                         .collect(toMap(PostImage::getPostId, PostImage::getObjectKey, (a, b) -> a));
 
         return posts.stream()
+                .filter(b -> detailPostMap.containsKey(((Post) b.getData()).getId()))
                 .map(
                         b -> {
                             PostWithUserAndBookmarkCountVo p =

--- a/src/main/java/com/ftm/server/application/service/post/GetUserPickPopularPostsService.java
+++ b/src/main/java/com/ftm/server/application/service/post/GetUserPickPopularPostsService.java
@@ -74,17 +74,17 @@ public class GetUserPickPopularPostsService implements GetUserPickPopularPostsUs
                         .stream()
                         .collect(toMap(PostImage::getPostId, PostImage::getObjectKey, (a, b) -> a));
 
-        // 합치기 (postList 순서 = 랭킹)
-        return IntStream.range(0, postIds.size())
+        // 합치기 (postList 순서 = 랭킹, soft-delete된 게시글은 detailPostMap에 없으므로 제외)
+        List<Long> validPostIds = postIds.stream().filter(detailPostMap::containsKey).toList();
+        return IntStream.range(0, validPostIds.size())
                 .mapToObj(
                         i -> {
-                            Long postId = postIds.get(i);
+                            Long postId = validPostIds.get(i);
                             PostWithUserAndBookmarkCountVo p = detailPostMap.get(postId);
                             int ranking = i + 1;
                             String imageUrl =
                                     imageUrlMap.getOrDefault(
-                                            p.getId(),
-                                            PropertiesHolder.POST_DEFAULT_IMAGE); // 없으면 null
+                                            p.getId(), PropertiesHolder.POST_DEFAULT_IMAGE);
                             return UserPickPopularPostsVo.of(
                                     ranking,
                                     p,

--- a/src/main/java/com/ftm/server/application/service/post/LoadUserPickBiblePostsService.java
+++ b/src/main/java/com/ftm/server/application/service/post/LoadUserPickBiblePostsService.java
@@ -75,17 +75,17 @@ public class LoadUserPickBiblePostsService implements LoadUserPickBiblePostsUseC
                         .stream()
                         .collect(toMap(PostImage::getPostId, PostImage::getObjectKey, (a, b) -> a));
 
-        // 합치기 (postList 순서 = 랭킹)
-        return IntStream.range(0, postIds.size())
+        // 합치기 (postList 순서 = 랭킹, soft-delete된 게시글은 detailPostMap에 없으므로 제외)
+        List<Long> validPostIds = postIds.stream().filter(detailPostMap::containsKey).toList();
+        return IntStream.range(0, validPostIds.size())
                 .mapToObj(
                         i -> {
-                            Long postId = postIds.get(i);
+                            Long postId = validPostIds.get(i);
                             PostWithUserAndBookmarkCountVo p = detailPostMap.get(postId);
                             int ranking = i + 1;
                             String imageUrl =
                                     imageUrlMap.getOrDefault(
-                                            p.getId(),
-                                            PropertiesHolder.POST_DEFAULT_IMAGE); // 없으면 null
+                                            p.getId(), PropertiesHolder.POST_DEFAULT_IMAGE);
                             return UserPickBiblePostsVo.of(
                                     ranking,
                                     p,

--- a/src/main/java/com/ftm/server/application/service/post/LoadUserPickTopBookmarkPostsService.java
+++ b/src/main/java/com/ftm/server/application/service/post/LoadUserPickTopBookmarkPostsService.java
@@ -72,17 +72,17 @@ public class LoadUserPickTopBookmarkPostsService implements LoadUserPickTopBookm
                         .stream()
                         .collect(toMap(PostImage::getPostId, PostImage::getObjectKey, (a, b) -> a));
 
-        // 합치기 (postList 순서 = 랭킹)
-        return IntStream.range(0, postIds.size())
+        // 합치기 (postList 순서 = 랭킹, soft-delete된 게시글은 detailPostMap에 없으므로 제외)
+        List<Long> validPostIds = postIds.stream().filter(detailPostMap::containsKey).toList();
+        return IntStream.range(0, validPostIds.size())
                 .mapToObj(
                         i -> {
-                            Long postId = postIds.get(i);
+                            Long postId = validPostIds.get(i);
                             PostWithUserAndBookmarkCountVo p = detailPostMap.get(postId);
                             int ranking = i + 1;
                             String imageUrl =
                                     imageUrlMap.getOrDefault(
-                                            p.getId(),
-                                            PropertiesHolder.POST_DEFAULT_IMAGE); // 없으면 null
+                                            p.getId(), PropertiesHolder.POST_DEFAULT_IMAGE);
                             return LoadUserPickTopBookmarkPostsVo.of(
                                     ranking,
                                     p,


### PR DESCRIPTION
- 게시글 삭제 시 AfterCommitExecutorPort를 통해 트랜잭션 커밋 후 모든 랭킹 캐시를 일괄 무효화 (EvictPostCachesPort/Adapter 추가)
- 캐시 구성용 쿼리(findTopNPostsByViewCountAndLikeCount, findTopNPostsByLikeCount, findAllPostsByPopular)에 isDeleted = false 필터 추가
- findAllPostsWithUserAndBookmarkCount(FindByIdsQuery)에 isDeleted 필터 추가로 삭제된 게시글이 상세 조회에 포함되지 않도록 수정
- findAllPostsByPopular() 정규화 기준값 쿼리에도 isDeleted 필터 추가로 점수 왜곡 방지
- findTopNPostsByLikeCount의 limit 파라미터 미사용 버그 수정
- 서비스 레이어에서 detailPostMap 기반 null-safety 필터 추가 (캐시 갱신 주기 내 race condition 방어)

## 🌱 관련 이슈

## 📌 작업 내용 및 특이사항


## 🔍 참고사항

-

## 📚 기타

-