### PR TITLE
refactor: CORS 허용 오리진 도메인 현행화 (.site -> .store) (#193)

### DIFF
--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
     public static final List<String> CORS_ALLOWED_ORIGINS =
             List.of(
                     "http://localhost:8080", // 로컬 환경 서버 도메인
-                    "https://dev-api.fittheman.site", // 개발 환경 서버 도메인
+                    "https://dev-api.fittheman.store", // 개발 환경 서버 도메인
                     "http://localhost:3000", // 로컬 환경 클라이언트 도메인
                     "https://localhost:3000", // 로컬 환경 https 클라이언트 도메인
                     "https://ftm-client.vercel.app", // 개발 환경 클라이언트 도메인


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #193 

## 📝 개요
API 서버 도메인 변경에 따라, 스프링 시큐리티 CORS 설정에 남아있던 구 도메인(`.site`) 주소를 현재 도메인(`.store`)으로 현행화합니다.

## 💡 변경 이유
- 현재 Swagger UI 환경은 API 서버와 동일 출처(**Same-Origin**) 상태로 수정 없이도 정상 동작합니다.
- 그러나 코드 정합성을 유지하고, 향후 프론트엔드 배포 서버 등 외부분 도메인에서 API를 호출할 때 발생할 수 있는 잠재적 CORS 에러를 선제적으로 방지하기 위해 수정합니다.

## 🛠️ 변경 사항
- `SecurityConfig` 내 CORS `allowedOrigins` 주소 수정
  - `https://dev-api.fittheman.site` ➡️ `https://dev-api.fittheman.store`

## ✅ 테스트 결과
- 개발 서버 Swagger UI를 통한 API 호출 및 정상 동작 확인