### PR TITLE
fix: Spring Security 로그아웃 URL 경로 수정 (#195)

### DIFF
--- a/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/ftm/server/infrastructure/security/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
         "/api/users/email/authentication",
         "/api/users/email/authentication/code",
         "/api/auth/login/**",
-        "api/auth/logout",
+        "/api/auth/logout",
         "/api/users",
         "/api/users/social",
         "/api/grooming/tests/submission",


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #195 

## 📌 작업 내용 및 특이사항

- Spring Security 설정 파일 내 로그아웃 관련 URL 접두사에 슬래시(`/`)가 누락된 버그 수정
- 수정 전: `api/auth/logout`, 수정 후: `/api/auth/logout `

## 🔍 참고사항

```
- GCP(Google Cloud Platform) 계정 크레딧 소진으로, 현재 배포된 개발(Dev) 서버 인스턴스가 중지(suspended) 된 상태
- 이로 인해 배포 실패 및 개발 서버 엔드포인트 접근 불가능
- 빠른 시일 내로 인스턴스 마이그레이션을 진행해 복구 예정
```

## 📚 기타

-