### PR TITLE
chore: 배포 환경 분리를 위한 GitHub Secrets 명명 규칙 변경 (#197)

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -99,16 +99,16 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}  # 추출된 도커 메타데이터 tags -> "${DOCKERHUB_USERNAME}/${DOCKERHUB_IMAGE_NAME}:{TAG}
 
-      # GCE 배포
-      - name: Deploy to GCE Server
+      # 배포
+      - name: Deploy to Server
         uses: appleboy/ssh-action@v1.0.3
         env:
           IMAGE_FULL_PATH: ${{ steps.metadata.outputs.tags }}
           DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}
         with:
-          host: ${{ secrets.GCE_HOST }}
-          username: ${{ secrets.GCE_USER }}
-          key: ${{ secrets.GCE_SSH_PRIVATE_KEY }}
+          host: ${{ secrets.DEV_SERVER_HOST }}
+          username: ${{ secrets.DEV_SERVER_USER }}
+          key: ${{ secrets.DEV_SERVER_SSH_PRIVATE_KEY }}
           envs: IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME # docker-compose.yml 에서 사용할 환경 변수
           debug: true
           script: |

--- a/.github/workflows/develop_build_deploy_manual.yml
+++ b/.github/workflows/develop_build_deploy_manual.yml
@@ -105,16 +105,16 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}  # 추출된 도커 메타데이터 tags -> "${DOCKERHUB_USERNAME}/${DOCKERHUB_IMAGE_NAME}:{TAG}
 
-      # GCE 배포
-      - name: Deploy to GCE Server
+      # 배포
+      - name: Deploy to Server
         uses: appleboy/ssh-action@v1.0.3
         env:
           IMAGE_FULL_PATH: ${{ steps.metadata.outputs.tags }}
           DOCKERHUB_IMAGE_NAME: ${{ env.DOCKERHUB_IMAGE_NAME }}
         with:
-          host: ${{ secrets.GCE_HOST }}
-          username: ${{ secrets.GCE_USER }}
-          key: ${{ secrets.GCE_SSH_PRIVATE_KEY }}
+          host: ${{ secrets.DEV_SERVER_HOST }}
+          username: ${{ secrets.DEV_SERVER_USER }}
+          key: ${{ secrets.DEV_SERVER_SSH_PRIVATE_KEY }}
           envs: IMAGE_FULL_PATH, DOCKERHUB_IMAGE_NAME # docker-compose.yml 에서 사용할 환경 변수
           debug: true
           script: |


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #197 

## 📌 작업 내용 및 특이사항

- 배포 서버 환경 변수 추상화
  - `특정 클라우드 공급자명(GCE_)`이 포함되어 있던 GitHub Secrets 명명 규칙을 배포 환경 기준(DEV_SERVER_)으로 전면 변경하여 인프라 종속성을 제거

- GitHub Actions 워크플로우(deploy.yml) 수정
  - 서버 이전(AWS, NCP, GCE 등) 시 CI/CD 스크립트 수정 없이 GitHub Secrets/Variables 설정만으로 유연하게 대처할 수 있도록 추상화된 변수를 적용

## 🔍 참고사항

- GitHub Secrets DEV environment에 `DEV_SERVER_HOST`, `DEV_SERVER_USER`, `DEV_SERVER_SSH_PRIVATE_KEY`를 추가하고 값 수정 완료

## 📚 기타

-