### PR TITLE
refactor: 그루밍 레벨 image_path 필드 추가 (#200)

### DIFF
--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/level/SaveGroomingLevelController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/level/SaveGroomingLevelController.java
@@ -31,7 +31,8 @@ public class SaveGroomingLevelController {
                         request.getNormalModeDescription(),
                         request.getTruthModeName(),
                         request.getTruthModeSummary(),
-                        request.getTruthModeDescription());
+                        request.getTruthModeDescription(),
+                        request.getImagePath());
         saveGroomingLevelUseCase.execute(command);
 
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/level/UpdateGroomingLevelController.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/controller/level/UpdateGroomingLevelController.java
@@ -21,7 +21,7 @@ public class UpdateGroomingLevelController {
     private final UpdateGroomingLevelUseCase updateGroomingLevelUseCase;
 
     @PatchMapping("/api/grooming/levels/{levelId}")
-    public ResponseEntity<ApiResponse<Void>> saveGroomingLevel(
+    public ResponseEntity<ApiResponse<Void>> updateGroomingLevel(
             @PathVariable Long levelId, @RequestBody @Valid UpdateGroomingLevelRequest request) {
 
         UpdateGroomingLevelCommand command =
@@ -34,7 +34,8 @@ public class UpdateGroomingLevelController {
                         request.getNormalModeDescription(),
                         request.getTruthModeName(),
                         request.getTruthModeSummary(),
-                        request.getTruthModeDescription());
+                        request.getTruthModeDescription(),
+                        request.getImagePath());
         updateGroomingLevelUseCase.execute(command);
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/SaveGroomingLevelRequest.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/SaveGroomingLevelRequest.java
@@ -22,4 +22,5 @@ public class SaveGroomingLevelRequest {
     @NotEmpty private String truthModeName;
     @NotEmpty private String truthModeSummary;
     @NotEmpty private String truthModeDescription;
+    private String imagePath;
 }

--- a/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/UpdateGroomingLevelRequest.java
+++ b/src/main/java/com/ftm/server/adapter/in/web/grooming/dto/request/UpdateGroomingLevelRequest.java
@@ -23,4 +23,5 @@ public class UpdateGroomingLevelRequest {
     private String truthModeName;
     private String truthModeSummary;
     private String truthModeDescription;
+    private String imagePath;
 }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/mapper/GroomingLevelMapper.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/mapper/GroomingLevelMapper.java
@@ -19,6 +19,7 @@ public class GroomingLevelMapper {
                 jpaEntity.getTruthModeName(),
                 jpaEntity.getTruthModeSummary(),
                 jpaEntity.getTruthModeDescription(),
+                jpaEntity.getImagePath(),
                 jpaEntity.getCreatedAt(),
                 jpaEntity.getUpdatedAt());
     }

--- a/src/main/java/com/ftm/server/adapter/out/persistence/model/GroomingLevelJpaEntity.java
+++ b/src/main/java/com/ftm/server/adapter/out/persistence/model/GroomingLevelJpaEntity.java
@@ -22,6 +22,7 @@ public class GroomingLevelJpaEntity extends BaseTimeJpaEntity {
     private String truthModeName;
     private String truthModeSummary;
     private String truthModeDescription;
+    private String imagePath;
 
     @Builder(access = AccessLevel.PRIVATE)
     private GroomingLevelJpaEntity(
@@ -32,7 +33,8 @@ public class GroomingLevelJpaEntity extends BaseTimeJpaEntity {
             String normalModeDescription,
             String truthModeName,
             String truthModeSummary,
-            String truthModeDescription) {
+            String truthModeDescription,
+            String imagePath) {
         this.minScore = minScore;
         this.maxScore = maxScore;
         this.normalModeName = normalModeName;
@@ -41,6 +43,7 @@ public class GroomingLevelJpaEntity extends BaseTimeJpaEntity {
         this.truthModeName = truthModeName;
         this.truthModeSummary = truthModeSummary;
         this.truthModeDescription = truthModeDescription;
+        this.imagePath = imagePath;
     }
 
     public static GroomingLevelJpaEntity from(GroomingLevel groomingLevel) {
@@ -53,6 +56,7 @@ public class GroomingLevelJpaEntity extends BaseTimeJpaEntity {
                 .truthModeName(groomingLevel.getTruthModeName())
                 .truthModeSummary(groomingLevel.getTruthModeSummary())
                 .truthModeDescription(groomingLevel.getTruthModeDescription())
+                .imagePath(groomingLevel.getImagePath())
                 .build();
     }
 
@@ -65,5 +69,6 @@ public class GroomingLevelJpaEntity extends BaseTimeJpaEntity {
         this.truthModeName = groomingLevel.getTruthModeName();
         this.truthModeSummary = groomingLevel.getTruthModeSummary();
         this.truthModeDescription = groomingLevel.getTruthModeDescription();
+        this.imagePath = groomingLevel.getImagePath();
     }
 }

--- a/src/main/java/com/ftm/server/application/command/grooming/level/SaveGroomingLevelCommand.java
+++ b/src/main/java/com/ftm/server/application/command/grooming/level/SaveGroomingLevelCommand.java
@@ -13,6 +13,7 @@ public class SaveGroomingLevelCommand {
     private final String truthModeName;
     private final String truthModeSummary;
     private final String truthModeDescription;
+    private final String imagePath;
 
     private SaveGroomingLevelCommand(
             Integer minScore,
@@ -22,7 +23,8 @@ public class SaveGroomingLevelCommand {
             String normalModeDescription,
             String truthModeName,
             String truthModeSummary,
-            String truthModeDescription) {
+            String truthModeDescription,
+            String imagePath) {
         this.minScore = minScore;
         this.maxScore = maxScore;
         this.normalModeName = normalModeName;
@@ -31,6 +33,7 @@ public class SaveGroomingLevelCommand {
         this.truthModeName = truthModeName;
         this.truthModeSummary = truthModeSummary;
         this.truthModeDescription = truthModeDescription;
+        this.imagePath = imagePath;
     }
 
     public static SaveGroomingLevelCommand of(
@@ -41,7 +44,8 @@ public class SaveGroomingLevelCommand {
             String normalModeDescription,
             String truthModeName,
             String truthModeSummary,
-            String truthModeDescription) {
+            String truthModeDescription,
+            String imagePath) {
         return new SaveGroomingLevelCommand(
                 minScore,
                 maxScore,
@@ -50,6 +54,7 @@ public class SaveGroomingLevelCommand {
                 normalModeDescription,
                 truthModeName,
                 truthModeSummary,
-                truthModeDescription);
+                truthModeDescription,
+                imagePath);
     }
 }

--- a/src/main/java/com/ftm/server/application/command/grooming/level/UpdateGroomingLevelCommand.java
+++ b/src/main/java/com/ftm/server/application/command/grooming/level/UpdateGroomingLevelCommand.java
@@ -14,6 +14,7 @@ public class UpdateGroomingLevelCommand {
     private final String truthModeName;
     private final String truthModeSummary;
     private final String truthModeDescription;
+    private final String imagePath;
 
     private UpdateGroomingLevelCommand(
             Long id,
@@ -24,7 +25,8 @@ public class UpdateGroomingLevelCommand {
             String normalModeDescription,
             String truthModeName,
             String truthModeSummary,
-            String truthModeDescription) {
+            String truthModeDescription,
+            String imagePath) {
         this.id = id;
         this.minScore = minScore;
         this.maxScore = maxScore;
@@ -34,6 +36,7 @@ public class UpdateGroomingLevelCommand {
         this.truthModeName = truthModeName;
         this.truthModeSummary = truthModeSummary;
         this.truthModeDescription = truthModeDescription;
+        this.imagePath = imagePath;
     }
 
     public static UpdateGroomingLevelCommand of(
@@ -45,7 +48,8 @@ public class UpdateGroomingLevelCommand {
             String normalModeDescription,
             String truthModeName,
             String truthModeSummary,
-            String truthModeDescription) {
+            String truthModeDescription,
+            String imagePath) {
         return new UpdateGroomingLevelCommand(
                 id,
                 minScore,
@@ -55,6 +59,7 @@ public class UpdateGroomingLevelCommand {
                 normalModeDescription,
                 truthModeName,
                 truthModeSummary,
-                truthModeDescription);
+                truthModeDescription,
+                imagePath);
     }
 }

--- a/src/main/java/com/ftm/server/application/vo/grooming/GroomingLevelVo.java
+++ b/src/main/java/com/ftm/server/application/vo/grooming/GroomingLevelVo.java
@@ -9,6 +9,18 @@ public class GroomingLevelVo {
     private final Long groomingLevelId;
     private final NormalModeLevel normalMode;
     private final TruthModeLevel truthMode;
+    private final String imagePath;
+
+    private GroomingLevelVo(GroomingLevel groomingLevel) {
+        this.groomingLevelId = groomingLevel.getId();
+        this.normalMode = NormalModeLevel.of(groomingLevel);
+        this.truthMode = TruthModeLevel.of(groomingLevel);
+        this.imagePath = groomingLevel.getImagePath();
+    }
+
+    public static GroomingLevelVo from(GroomingLevel groomingLevel) {
+        return new GroomingLevelVo(groomingLevel);
+    }
 
     @Getter
     public static class NormalModeLevel {
@@ -44,15 +56,5 @@ public class GroomingLevelVo {
         public static TruthModeLevel of(GroomingLevel groomingLevel) {
             return new TruthModeLevel(groomingLevel);
         }
-    }
-
-    private GroomingLevelVo(GroomingLevel groomingLevel) {
-        this.groomingLevelId = groomingLevel.getId();
-        this.normalMode = NormalModeLevel.of(groomingLevel);
-        this.truthMode = TruthModeLevel.of(groomingLevel);
-    }
-
-    public static GroomingLevelVo from(GroomingLevel groomingLevel) {
-        return new GroomingLevelVo(groomingLevel);
     }
 }

--- a/src/main/java/com/ftm/server/domain/entity/GroomingLevel.java
+++ b/src/main/java/com/ftm/server/domain/entity/GroomingLevel.java
@@ -21,6 +21,7 @@ public class GroomingLevel extends BaseTime {
     private String truthModeName;
     private String truthModeSummary;
     private String truthModeDescription;
+    private String imagePath;
 
     @Builder(access = AccessLevel.PRIVATE)
     private GroomingLevel(
@@ -33,6 +34,7 @@ public class GroomingLevel extends BaseTime {
             String truthModeName,
             String truthModeSummary,
             String truthModeDescription,
+            String imagePath,
             LocalDateTime createdAt,
             LocalDateTime updatedAt) {
         this.id = id;
@@ -44,6 +46,7 @@ public class GroomingLevel extends BaseTime {
         this.truthModeName = truthModeName;
         this.truthModeSummary = truthModeSummary;
         this.truthModeDescription = truthModeDescription;
+        this.imagePath = imagePath;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -58,6 +61,7 @@ public class GroomingLevel extends BaseTime {
             String truthModeName,
             String truthModeSummary,
             String truthModeDescription,
+            String imagePath,
             LocalDateTime createdAt,
             LocalDateTime updatedAt) {
         return GroomingLevel.builder()
@@ -70,6 +74,7 @@ public class GroomingLevel extends BaseTime {
                 .truthModeName(truthModeName)
                 .truthModeSummary(truthModeSummary)
                 .truthModeDescription(truthModeDescription)
+                .imagePath(imagePath)
                 .createdAt(createdAt)
                 .updatedAt(updatedAt)
                 .build();
@@ -85,6 +90,7 @@ public class GroomingLevel extends BaseTime {
                 .truthModeName(command.getTruthModeName())
                 .truthModeSummary(command.getTruthModeSummary())
                 .truthModeDescription(command.getTruthModeDescription())
+                .imagePath(command.getImagePath())
                 .build();
     }
 
@@ -101,5 +107,6 @@ public class GroomingLevel extends BaseTime {
             this.truthModeSummary = command.getTruthModeSummary();
         if (command.getTruthModeDescription() != null)
             this.truthModeDescription = command.getTruthModeDescription();
+        if (command.getImagePath() != null) this.imagePath = command.getImagePath();
     }
 }

--- a/src/test/java/com/ftm/server/grooming/LoadGroomingTestHistoryDetailTest.java
+++ b/src/test/java/com/ftm/server/grooming/LoadGroomingTestHistoryDetailTest.java
@@ -130,7 +130,10 @@ public class LoadGroomingTestHistoryDetailTest extends BaseTest {
                             .description("그루밍 레벨 진심모드 요약"),
                     fieldWithPath("data.level.truthMode.description")
                             .type(STRING)
-                            .description("그루밍 레벨 진심모드 설명"));
+                            .description("그루밍 레벨 진심모드 설명"),
+                    fieldWithPath("data.level.imagePath")
+                            .type(STRING)
+                            .description("그루밍 레벨 이미지 경로"));
 
     private RestDocumentationResultHandler getDocument(Integer identifier) {
         return document(

--- a/src/test/java/com/ftm/server/grooming/SubmitGroomingTestsTest.java
+++ b/src/test/java/com/ftm/server/grooming/SubmitGroomingTestsTest.java
@@ -121,21 +121,58 @@ public class SubmitGroomingTestsTest extends BaseTest {
                             .description("그루밍 레벨 진심모드 요약"),
                     fieldWithPath("data.level.truthMode.description")
                             .type(STRING)
-                            .description("그루밍 레벨 진심모드 설명"));
+                            .description("그루밍 레벨 진심모드 설명"),
+                    fieldWithPath("data.level.imagePath")
+                            .type(STRING)
+                            .description("그루밍 레벨 이미지 경로"));
 
     private GroomingTestSubmissionRequest getRequest() {
         List<GroomingTestSubmissionRequest.SubmittedQuestion> submissions =
                 List.of(
                         new GroomingTestSubmissionRequest.SubmittedQuestion(
-                                1L, "BEAUTY", List.of(1L, 2L, 3L)),
+                                1L, "BEAUTY", List.of(1L, 2L, 3L, 4L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                2L, "BEAUTY", List.of(7L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                3L, "BEAUTY", List.of(8L, 9L, 10L, 11L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                4L, "BEAUTY", List.of(13L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                5L, "BEAUTY", List.of(16L)),
                         new GroomingTestSubmissionRequest.SubmittedQuestion(
                                 6L, "HYGIENE", List.of(18L)),
                         new GroomingTestSubmissionRequest.SubmittedQuestion(
-                                10L, "HAIR", List.of(32L)),
+                                7L, "HYGIENE", List.of(20L, 21L, 22L)),
                         new GroomingTestSubmissionRequest.SubmittedQuestion(
-                                15L, "WORKOUT", List.of(46L, 47L, 48L)),
+                                8L, "HYGIENE", List.of(26L, 27L)),
                         new GroomingTestSubmissionRequest.SubmittedQuestion(
-                                18L, "FASHION", List.of(67L, 68L)));
+                                9L, "HYGIENE", List.of(28L, 29L, 30L, 31L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                10L, "HAIR", List.of(33L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                11L, "HAIR", List.of(35L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                12L, "HAIR", List.of(37L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                13L, "HAIR", List.of(40L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                14L, "HAIR", List.of(42L, 44L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                15L, "WORKOUT", List.of(47L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                16L, "WORKOUT", List.of(59L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                17L, "WORKOUT", List.of(61L, 63L, 64L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                18L, "FASHION", List.of(67L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                19L, "FASHION", List.of(71L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                20L, "FASHION", List.of(74L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                21L, "FASHION", List.of(77L)),
+                        new GroomingTestSubmissionRequest.SubmittedQuestion(
+                                22L, "FASHION", List.of(80L)));
         return new GroomingTestSubmissionRequest(submissions);
     }
 

--- a/src/test/java/com/ftm/server/grooming/level/DeleteGroomingLevelTest.java
+++ b/src/test/java/com/ftm/server/grooming/level/DeleteGroomingLevelTest.java
@@ -41,7 +41,8 @@ public class DeleteGroomingLevelTest extends BaseTest {
                         "레벨 일반모드 설명",
                         "레벨 진심모드 이름",
                         "레벨 진심모드 요약",
-                        "레벨 진심모드 설명");
+                        "레벨 진심모드 설명",
+                        "https://test-image-path");
         GroomingLevel level = GroomingLevel.create(command);
         levelId = groomingLevelRepository.save(groomingLevelMapper.toJpaEntity(level)).getId();
     }

--- a/src/test/java/com/ftm/server/grooming/level/SaveGroomingLevelTest.java
+++ b/src/test/java/com/ftm/server/grooming/level/SaveGroomingLevelTest.java
@@ -37,7 +37,8 @@ public class SaveGroomingLevelTest extends BaseTest {
                         "레벨 일반모드 설명",
                         "레벨 진심모드 이름",
                         "레벨 진심모드 요약",
-                        "레벨 진심모드 설명");
+                        "레벨 진심모드 설명",
+                        "https://test-image-path");
 
         // when
         MockHttpSession session = createAdminUserAndLogin();
@@ -60,7 +61,8 @@ public class SaveGroomingLevelTest extends BaseTest {
                         "레벨 일반모드 설명",
                         "레벨 진심모드 이름",
                         "레벨 진심모드 요약",
-                        "레벨 진심모드 설명");
+                        "레벨 진심모드 설명",
+                        "https://test-image-path");
 
         // when
         MockHttpSession session = createUserAndLogin();
@@ -85,7 +87,8 @@ public class SaveGroomingLevelTest extends BaseTest {
                         "레벨 일반모드 설명",
                         "레벨 진심모드 이름",
                         "레벨 진심모드 요약",
-                        "레벨 진심모드 설명");
+                        "레벨 진심모드 설명",
+                        "https://test-image-path");
 
         // when
         MockHttpSession session = createAdminUserAndLogin();

--- a/src/test/java/com/ftm/server/grooming/level/UpdateGroomingLevelTest.java
+++ b/src/test/java/com/ftm/server/grooming/level/UpdateGroomingLevelTest.java
@@ -47,7 +47,8 @@ public class UpdateGroomingLevelTest extends BaseTest {
                         "레벨 일반모드 설명",
                         "레벨 진심모드 이름",
                         "레벨 진심모드 요약",
-                        "레벨 진심모드 설명");
+                        "레벨 진심모드 설명",
+                        "https://test-image-path");
         GroomingLevel level = GroomingLevel.create(command);
         levelId = groomingLevelRepository.save(groomingLevelMapper.toJpaEntity(level)).getId();
     }
@@ -65,7 +66,8 @@ public class UpdateGroomingLevelTest extends BaseTest {
                         "레벨 일반모드 설명",
                         "레벨 진심모드 이름",
                         "레벨 진심모드 요약",
-                        "레벨 진심모드 설명");
+                        "레벨 진심모드 설명",
+                        "https://test-image-path");
 
         // when
         MockHttpSession session = createAdminUserAndLogin();
@@ -80,7 +82,7 @@ public class UpdateGroomingLevelTest extends BaseTest {
     void 그루밍_레벨_수정_실패1() throws Exception {
         // given
         UpdateGroomingLevelRequest request =
-                new UpdateGroomingLevelRequest(1, 9, null, null, null, null, null, null);
+                new UpdateGroomingLevelRequest(1, 9, null, null, null, null, null, null, null);
 
         // when
         MockHttpSession session = createUserAndLogin();
@@ -97,7 +99,7 @@ public class UpdateGroomingLevelTest extends BaseTest {
     void 그루밍_레벨_수정_실패2() throws Exception {
         // given
         UpdateGroomingLevelRequest request =
-                new UpdateGroomingLevelRequest(1, 9, null, null, null, null, null, null);
+                new UpdateGroomingLevelRequest(1, 9, null, null, null, null, null, null, null);
 
         // when
         MockHttpSession session = createAdminUserAndLogin();


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- # 뒤에 이슈 번호를 추가해주세요 -->
- close #200 

## 📌 작업 내용 및 특이사항
- 그루밍 레벨 엔티티에 image_path 필드 추가
- 그루밍 레벨별 이미지 경로 데이터 추가
- 그루밍 레벨 VO 및 응답 구조 리팩토링
- 그루밍 레벨 생성/수정 API 요청 및 응답 리팩토링
- 관련 그루밍 테스트 제출, 이력 조회, 레벨 생성/수정/삭제 테스트 코드 수정

## 🔍 참고사항
- S3에 그루밍 레벨별 이미지 업로드했습니다.
- 그루밍 레벨 이미지는 운영자가 관리하는 고정 데이터로, image_path를 통해 관리하도록 반영했습니다.
- 기존 초기 데이터 및 테스트 데이터에 레벨별 이미지 경로를 추가했습니다.

## 📚 기타

- PR(#198) 먼저 병합한 이후에 병합해야함.